### PR TITLE
Omit fields with empty collections

### DIFF
--- a/core/src/main/boilerplate/sjsonnew/TupleFormats.scala.template
+++ b/core/src/main/boilerplate/sjsonnew/TupleFormats.scala.template
@@ -31,14 +31,19 @@ trait TupleFormats {
       ]
       builder.endArray()
     }
-    def read[J](js: J, unbuilder: Unbuilder[J]): Tuple1[[#A1#]] = {
-      unbuilder.beginArray(js)
-      [#val a1 = unbuilder.nextElement#
-      ]
-      val xs = Tuple1([#a1Format.read(a1, unbuilder)#])
-      unbuilder.endArray()
-      xs
-    }
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Tuple1[[#A1#]] =
+      jsOpt match {
+        case Some(js) =>
+          unbuilder.beginArray(js)
+          [#val a1 = unbuilder.nextElement#
+          ]
+          val xs = Tuple1([#a1Format.read(Some(a1), unbuilder)#])
+          unbuilder.endArray()
+          xs
+        case None =>
+          val xs = Tuple1([#a1Format.read(None, unbuilder)#])
+          xs
+      }
   }#
   ]
 }

--- a/core/src/main/boilerplate/sjsonnew/UnionFormats.scala.template
+++ b/core/src/main/boilerplate/sjsonnew/UnionFormats.scala.template
@@ -9,32 +9,35 @@ trait UnionFormats {
 
     def write[J](u: U, builder: Builder[J]): Unit = {
       builder.beginObject()
-      builder.addField("value")
+      builder.addFieldName("value")
       u match {
       [#  case x if implicitly[Manifest[A1]].runtimeClass == x.getClass => a1Format.write(x.asInstanceOf[A1], builder)#
       ]
       }
-      builder.addField("type")
+      builder.addFieldName("type")
       builder.writeString(className(u.getClass))
       builder.endObject()
     }
-    def read[J](js: J, unbuilder: Unbuilder[J]): U = {
-      unbuilder.beginObject(js)
-      val typeName = unbuilder.lookupField("type") match {
-        case Some(x) => unbuilder.readString(x)
-        case None    => deserializationError("Field not found: $type")
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): U =
+      jsOpt match {
+        case Some(js) =>
+          unbuilder.beginObject(js)
+          val typeName = unbuilder.lookupField("type") match {
+            case Some(x) => unbuilder.readString(x)
+            case None    => deserializationError("Field not found: $type")
+          }
+          val valueJs = unbuilder.lookupField("value") match {
+            case Some(x) => x
+            case None    => deserializationError("Field not found: value")
+          }
+          val value = typeName match {
+          [#  case x if className(implicitly[Manifest[A1]].runtimeClass) == x => a1Format.read(Some(valueJs), unbuilder)#
+          ]
+          }
+          unbuilder.endObject()
+          value match { case u: U @unchecked => u }
+        case None => deserializationError("Expected union JsObject, but got None")
       }
-      val valueJs = unbuilder.lookupField("value") match {
-        case Some(x) => x
-        case None    => deserializationError("Field not found: value")
-      }
-      val value = typeName match {
-      [#  case x if className(implicitly[Manifest[A1]].runtimeClass) == x => a1Format.read(valueJs, unbuilder)#
-      ]
-      }
-      unbuilder.endObject()
-      value match { case u: U @unchecked => u }
-    }
   }#
   ]
 

--- a/core/src/main/scala/sjsonnew/Builder.scala
+++ b/core/src/main/scala/sjsonnew/Builder.scala
@@ -37,16 +37,19 @@ class Builder[J](facade: Facade[J]) {
       case InObject =>
         // This is effectively same as addField, but allows to use keyFormat.write.
         if (contexts.isEmpty) serializationError("The builder state is InObject, but the context is empty.")
-        else contexts.top.add(x)
+        else contexts.top.addField(x)
         state = InField
       case _ => writeJ(facade.jstring(x))
     }
+
+  def addField[A](field: String, a: A)(implicit format: JsonFormat[A]): Unit =
+    format.addField(field, a, this)
   /** Write field name to the current context. */
-  def addField(x: String): Unit =
+  def addFieldName(field: String): Unit =
     state match {
       case InObject =>
         if (contexts.isEmpty) serializationError("The builder state is InObject, but the context is empty.")
-        else contexts.top.add(x)
+        else contexts.top.addField(field)
         state = InField
       case x => stateError(x)
     }
@@ -84,6 +87,7 @@ class Builder[J](facade: Facade[J]) {
     }
   /** Checks if the current state is `InObject` */
   def isInObject: Boolean = state == InObject
+
   /** Begins JObject. The builder state will be in `BuilderState.InObject`.
     * Make pairs `addField("abc")` and `writeXXX` calls to make field entries,
     * and end with `endObject`.

--- a/core/src/main/scala/sjsonnew/Facade.scala
+++ b/core/src/main/scala/sjsonnew/Facade.scala
@@ -67,7 +67,7 @@ trait Facade[J] {
  * cases where the entire JSON document consists of "333.33".
  */
 trait FContext[J] {
-  def add(s: String): Unit
+  def addField(s: String): Unit
   def add(v: J): Unit
   def finish: J
   def isObj: Boolean

--- a/core/src/main/scala/sjsonnew/IsoFormats.scala
+++ b/core/src/main/scala/sjsonnew/IsoFormats.scala
@@ -21,15 +21,18 @@ trait IsoFormats {
     val iso = implicitly[IsoLList[A]]
     def write[J](x: A, builder: Builder[J]): Unit =
       iso.jsonFormat.write(iso.to(x), builder)
-    def read[J](js: J, unbuilder: Unbuilder[J]): A =
-      iso.from(iso.jsonFormat.read(js, unbuilder))
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A =
+      iso.from(iso.jsonFormat.read(jsOpt, unbuilder))
   }
 
   implicit def isoStringFormat[A: IsoString]: JsonFormat[A] = new JsonFormat[A] {
     val iso = implicitly[IsoString[A]]
     def write[J](x: A, builder: Builder[J]): Unit =
       builder.writeString(iso.to(x))
-    def read[J](js: J, unbuilder: Unbuilder[J]): A =
-      iso.from(unbuilder.readString(js))
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A =
+      jsOpt match {
+        case Some(js) => iso.from(unbuilder.readString(js))
+        case None     => iso.from("")
+      }
   }
 }

--- a/core/src/main/scala/sjsonnew/JsonFormat.scala
+++ b/core/src/main/scala/sjsonnew/JsonFormat.scala
@@ -25,7 +25,7 @@ import annotation.implicitNotFound
  */
 @implicitNotFound(msg = "Cannot find JsonReader or JsonFormat type class for ${A}")
 trait JsonReader[A] {
-  def read[J](js: J, unbuilder: Unbuilder[J]): A
+  def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A
 }
 
 /**
@@ -34,6 +34,11 @@ trait JsonReader[A] {
 @implicitNotFound(msg = "Cannot find JsonWriter or JsonFormat type class for ${A}")
 trait JsonWriter[A] {
   def write[J](obj: A, builder: Builder[J]): Unit
+  def addField[J](name: String, obj: A, builder: Builder[J]): Unit =
+    {
+      builder.addFieldName(name)
+      write(obj, builder)
+    }
 }
 
 /**

--- a/core/src/main/scala/sjsonnew/PrimitiveFormats.scala
+++ b/core/src/main/scala/sjsonnew/PrimitiveFormats.scala
@@ -25,50 +25,71 @@ trait PrimitiveFormats {
   implicit object IntJsonFormat extends JsonFormat[Int] {
     def write[J](x: Int, builder: Builder[J]): Unit =
       builder.writeInt(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Int =
-      unbuilder.readInt(js)
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Int =
+      jsOpt match {
+        case Some(js) => unbuilder.readInt(js)
+        case None     => 0
+      }
   }
 
   implicit object LongJsonFormat extends JsonFormat[Long] {
     def write[J](x: Long, builder: Builder[J]): Unit =
       builder.writeLong(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Long =
-      unbuilder.readLong(js)
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Long =
+      jsOpt match {
+        case Some(js) => unbuilder.readLong(js)
+        case None     => 0L
+      }
   }
 
   implicit object FloatJsonFormat extends JsonFormat[Float] {
     def write[J](x: Float, builder: Builder[J]): Unit =
       builder.writeDouble(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Float =
-      unbuilder.readFloat(js)
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Float =
+      jsOpt match {
+        case Some(js) => unbuilder.readFloat(js)
+        case None     => 0.0f
+      }
   }
 
   implicit object DoubleJsonFormat extends JsonFormat[Double] {
     def write[J](x: Double, builder: Builder[J]): Unit =
       builder.writeDouble(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Double =
-      unbuilder.readDouble(js)
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Double =
+      jsOpt match {
+        case Some(js) => unbuilder.readDouble(js)
+        case None     => 0.0
+      }
   }
 
   implicit object ByteJsonFormat extends JsonFormat[Byte] {
     def write[J](x: Byte, builder: Builder[J]): Unit =
       builder.writeInt(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Byte =
-      unbuilder.readInt(js).toByte
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Byte =
+      jsOpt match {
+        case Some(js) => unbuilder.readInt(js).toByte
+        case None     => 0.toByte
+      }
   }
 
   implicit object ShortJsonFormat extends JsonFormat[Short] {
     def write[J](x: Short, builder: Builder[J]): Unit =
       builder.writeInt(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Short =
-      unbuilder.readInt(js).toShort
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Short =
+      jsOpt match {
+        case Some(js) => unbuilder.readInt(js).toShort
+        case None     => 0.toShort
+      }
   }
 
   implicit object BigDecimalJsonFormat extends JsonFormat[BigDecimal] {
     def write[J](x: BigDecimal, builder: Builder[J]): Unit =
       builder.writeBigDecimal(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): BigDecimal =
-      unbuilder.readBigDecimal(js)
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): BigDecimal =
+      jsOpt match {
+        case Some(js) => unbuilder.readBigDecimal(js)
+        case None     => BigDecimal(0)
+      }
   }
 
   implicit object BigIntJsonFormat extends JsonFormat[BigInt] {
@@ -76,46 +97,61 @@ trait PrimitiveFormats {
       require(x ne null)
       builder.writeBigDecimal(BigDecimal(x))
     }
-    def read[J](js: J, unbuilder: Unbuilder[J]): BigInt =
-      unbuilder.readBigDecimal(js).toBigInt
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): BigInt =
+      jsOpt match {
+        case Some(js) => unbuilder.readBigDecimal(js).toBigInt
+        case None     => BigInt(0)
+      }
   }
 
   implicit object UnitJsonFormat extends JsonFormat[Unit] {
     def write[J](x: Unit, builder: Builder[J]): Unit =
       builder.writeInt(1)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Unit = ()
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Unit = ()
   }
 
   implicit object BooleanJsonFormat extends JsonFormat[Boolean] {
     def write[J](x: Boolean, builder: Builder[J]): Unit =
       builder.writeBoolean(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Boolean =
-      unbuilder.readBoolean(js)
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Boolean =
+      jsOpt match {
+        case Some(js) => unbuilder.readBoolean(js)
+        case None     => false
+      }
   }
 
   implicit object CharJsonFormat extends JsonFormat[Char] {
     def write[J](x: Char, builder: Builder[J]): Unit =
       builder.writeString(String.valueOf(x))
-    def read[J](js: J, unbuilder: Unbuilder[J]): Char = {
-      val str = unbuilder.readString(js)
-      if (str.length == 1) str.charAt(0)
-      else deserializationError("Expected Char as single-character JsString, but got " + str)
-    }
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Char =
+      jsOpt match {
+        case Some(js) =>
+          val str = unbuilder.readString(js)
+          if (str.length == 1) str.charAt(0)
+          else deserializationError("Expected Char as single-character JsString, but got " + str)
+        case None => deserializationError("Expected Char as single-character JsString, but got None")
+      }
   }
 
   implicit object StringJsonFormat extends JsonFormat[String] {
     def write[J](x: String, builder: Builder[J]): Unit =
       builder.writeString(x)
-    def read[J](js: J, unbuilder: Unbuilder[J]): String =
-      unbuilder.readString(js)
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): String =
+      jsOpt match {
+        case Some(js) => unbuilder.readString(js)
+        case None     => ""
+      }
   }
 
   implicit object SymbolJsonFormat extends JsonFormat[Symbol] {
     def write[J](x: Symbol, builder: Builder[J]): Unit =
       builder.writeString(x.name)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Symbol = {
-      val str = unbuilder.readString(js)
-      Symbol(str)
-    }
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Symbol =
+      jsOpt match {
+        case Some(js) =>
+          val str = unbuilder.readString(js)
+          Symbol(str)
+        case None => deserializationError("Expected Symbol as JsString, but got None")
+      }
   }
 }

--- a/core/src/main/scala/sjsonnew/SimpleFacade.scala
+++ b/core/src/main/scala/sjsonnew/SimpleFacade.scala
@@ -36,7 +36,7 @@ trait SimpleFacade[J] extends Facade[J] {
 
   def singleContext() = new FContext[J] {
     var value: J = _
-    def add(s: String) { value = jstring(s) }
+    def addField(s: String): Unit = { value = jstring(s) }
     def add(v: J) { value = v }
     def finish: J = value
     def isObj: Boolean = false
@@ -44,7 +44,7 @@ trait SimpleFacade[J] extends Facade[J] {
 
   def arrayContext() = new FContext[J] {
     val vs = mutable.ListBuffer.empty[J]
-    def add(s: String) { vs += jstring(s) }
+    def addField(s: String): Unit = { vs += jstring(s) }
     def add(v: J) { vs += v }
     def finish: J = jarray(vs.toList)
     def isObj: Boolean = false
@@ -53,8 +53,9 @@ trait SimpleFacade[J] extends Facade[J] {
   def objectContext() = new FContext[J] {
     var key: String = null
     var vs = Map.empty[String, J]
-    def add(s: String): Unit =
-      if (key == null) { key = s } else { vs = vs.updated(key, jstring(s)); key = null }
+    def addField(s: String): Unit =
+      if (key == null) { key = s }
+      else { vs = vs.updated(key, jstring(s)); key = null }
     def add(v: J): Unit =
       { vs = vs.updated(key, v); key = null }
     def finish = jobject(vs)

--- a/core/src/main/scala/sjsonnew/SupportConverter.scala
+++ b/core/src/main/scala/sjsonnew/SupportConverter.scala
@@ -31,15 +31,22 @@ trait SupportConverter[J] {
     * Convert a JSON AST of type `J` to an object of type `A`.
     */
   def fromJson[A](js: J)(implicit reader: JsonReader[A]): Try[A] =
-    Try(fromJsonUnsafe[A](js)(reader))
+    Try(fromJsonOptionUnsafe[A](Some(js))(reader))
 
   /**
     * Convert a JSON AST of type `J` to an object of type `A`.
     * This might fail by throwing an exception.
     */
   def fromJsonUnsafe[A](js: J)(implicit reader: JsonReader[A]): A =
+    fromJsonOptionUnsafe(Some(js))(reader)
+
+  /**
+    * Convert a JSON AST of type `J` to an object of type `A`.
+    * This might fail by throwing an exception.
+    */
+  def fromJsonOptionUnsafe[A](jsOpt: Option[J])(implicit reader: JsonReader[A]): A =
     {
       val unbuilder = makeUnbuilder
-      reader.read[J](js, unbuilder)
+      reader.read[J](jsOpt, unbuilder)
     }
 }

--- a/core/src/main/scala/sjsonnew/Unbuilder.scala
+++ b/core/src/main/scala/sjsonnew/Unbuilder.scala
@@ -116,6 +116,9 @@ class Unbuilder[J](facade: Facade[J]) {
         }
       case x => stateError(x)
     }
+  def readField[A: JsonFormat](name: String): A =
+    implicitly[JsonFormat[A]].read(lookupField(name), this)
+
   /** End reading JSON object. Returns the size. */
   def endObject(): Unit =
     state match {

--- a/support/json4s/src/main/scala/sjsonnew/support/json4s/Converter.scala
+++ b/support/json4s/src/main/scala/sjsonnew/support/json4s/Converter.scala
@@ -21,7 +21,7 @@ object Converter extends SupportConverter[JValue] {
     def singleContext() =
       new FContext[JValue] {
         var value: JValue = null
-        def add(s: String) { value = jstring(s) }
+        def addField(s: String): Unit = { value = jstring(s) }
         def add(v: JValue) { value = v }
         def finish: JValue = value
         def isObj: Boolean = false
@@ -30,7 +30,7 @@ object Converter extends SupportConverter[JValue] {
     def arrayContext() =
       new FContext[JValue] {
         val vs = mutable.ListBuffer.empty[JValue]
-        def add(s: String) { vs += jstring(s) }
+        def addField(s: String): Unit = { vs += jstring(s) }
         def add(v: JValue) { vs += v }
         def finish: JValue = JArray(vs.toList)
         def isObj: Boolean = false
@@ -40,7 +40,7 @@ object Converter extends SupportConverter[JValue] {
       new FContext[JValue] {
         var key: String = null
         var vs = List.empty[JField]
-        def add(s: String): Unit =
+        def addField(s: String): Unit =
           if (key == null) key = s
           else { vs = JField(key, jstring(s)) :: vs; key = null }
         def add(v: JValue): Unit =

--- a/support/spray/src/test/scala/sjsonnew/support/spray/BuilderSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/BuilderSpec.scala
@@ -27,25 +27,21 @@ class BuilderSpec extends Specification with BasicJsonProtocol {
   implicit object PersonFormat extends JsonFormat[Person] {
     def write[J](x: Person, builder: Builder[J]): Unit = {
       builder.beginObject()
-      builder.addField("name")
-      builder.writeString(x.name)
-      builder.addField("value")
-      builder.writeInt(x.value)
+      builder.addField("name", x.name)
+      builder.addField("value", x.value)
       builder.endObject()
     }
-    def read[J](js: J, unbuilder: Unbuilder[J]): Person = {
-      unbuilder.beginObject(js)
-      val name = unbuilder.lookupField("name") match {
-        case Some(x) => unbuilder.readString(x)
-        case _       => deserializationError(s"Missing field: name")
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Person =
+      jsOpt match {
+        case Some(js) =>
+          unbuilder.beginObject(js)
+          val name = unbuilder.readField[String]("name")
+          val value = unbuilder.readField[Int]("value")
+          unbuilder.endObject()
+          Person(name, value)
+        case None =>
+          deserializationError("Expected JsObject but found None")
       }
-      val value = unbuilder.lookupField("value") match {
-        case Some(x) => unbuilder.readInt(x)
-        case _       => 0
-      }
-      unbuilder.endObject()
-      Person(name, value)
-    }
   }
 
   "Custom format using builder" should {

--- a/support/spray/src/test/scala/sjsonnew/support/spray/UnionFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/UnionFormatSpec.scala
@@ -29,19 +29,27 @@ class UnionFormatsSpec extends Specification with BasicJsonProtocol {
   implicit object AppleJsonFormat extends JsonFormat[Apple] {
     def write[J](x: Apple, builder: Builder[J]): Unit =
       builder.writeInt(0)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Apple =
-      unbuilder.readInt(js) match {
-        case 0 => Apple()
-        case x => deserializationError(s"Unexpected value: $x")
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Apple =
+      jsOpt match {
+        case Some(js) =>
+          unbuilder.readInt(js) match {
+            case 0 => Apple()
+            case x => deserializationError(s"Unexpected value: $x")
+          }
+        case None => deserializationError("Expected JsNumber but found None")
       }
   }
   implicit object OrangeJsonFormat extends JsonFormat[Orange] {
     def write[J](x: Orange, builder: Builder[J]): Unit =
       builder.writeInt(1)
-    def read[J](js: J, unbuilder: Unbuilder[J]): Orange =
-      unbuilder.readInt(js) match {
-        case 1 => Orange()
-        case x => deserializationError(s"Unexpected value: $x")
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Orange =
+      jsOpt match {
+        case Some(js) =>
+          unbuilder.readInt(js) match {
+            case 1 => Orange()
+            case x => deserializationError(s"Unexpected value: $x")
+          }
+        case None => deserializationError("Expected JsNumber but found None")
       }
   }
   implicit val FruitFormat = unionFormat2[Fruit, Apple, Orange]


### PR DESCRIPTION
For `Option[A]` and collections, omit the fields that are empty.
On the reading side, assume empty values when a field is not found.
This makes conversion more permissive, and allows some limited
evolution of the schema.