### PR TITLE
Add `wrap` and `asSingleton` serializers

### DIFF
--- a/core/src/main/scala/sjsonnew/AdditionalFormats.scala
+++ b/core/src/main/scala/sjsonnew/AdditionalFormats.scala
@@ -97,4 +97,20 @@ trait AdditionalFormats {
     }
   }
 
+  /**
+   * A `JsonFormat` that doesn't write and always return this instance of `a`.
+   */
+  def asSingleton[A](a: A): JsonFormat[A] = new JsonFormat[A] {
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A = a
+    def write[J](obj: A, builder: Builder[J]): Unit = ()
+  }
+
+  /**
+   * A `JsonFormat` that can read and write an instance of `T` by using a `JsonFormat` for `U`.
+   */
+  def wrap[T, U](f1: T => U, f2: U => T)(implicit fu: JsonFormat[U]): JsonFormat[T] = new JsonFormat[T] {
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): T = f2(fu.read(jsOpt, unbuilder))
+    def write[J](obj: T, builder: Builder[J]): Unit = fu.write(f1(obj), builder)
+  }
+
 }

--- a/core/src/main/scala/sjsonnew/AdditionalFormats.scala
+++ b/core/src/main/scala/sjsonnew/AdditionalFormats.scala
@@ -108,7 +108,7 @@ trait AdditionalFormats {
   /**
    * A `JsonFormat` that can read and write an instance of `T` by using a `JsonFormat` for `U`.
    */
-  def wrap[T, U](f1: T => U, f2: U => T)(implicit fu: JsonFormat[U]): JsonFormat[T] = new JsonFormat[T] {
+  def project[T, U](f1: T => U, f2: U => T)(implicit fu: JsonFormat[U]): JsonFormat[T] = new JsonFormat[T] {
     def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): T = f2(fu.read(jsOpt, unbuilder))
     def write[J](obj: T, builder: Builder[J]): Unit = fu.write(f1(obj), builder)
   }


### PR DESCRIPTION
 - `wrap` allows to define a `JsonFormat[T]` from a `JsonFormat[U]`
   given a function that transforms an instance of `T` to an instance of
   `U`.

 - Given an instance `i` of `T`, `asSingleton` will create a `JsonFormat[T]`
   that will not generate any trying to serialize a `T` and always
   return `i` when trying to decode an instance a `T`.