### PR TITLE
improve date time formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val root = (project in file(".")).
       developers in ThisBuild := List(
         Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("https://github.com/eed3si9n"))
       ),
-      version := "0.4.1",
+      version := "0.4.2-SNAPSHOT",
       crossScalaVersions := Seq("2.10.6", "2.11.8"),
       scalaVersion := "2.11.8",
       description := "A Scala library for JSON (de)serialization",

--- a/core/src/main/scala/sjsonnew/CalendarFormats.scala
+++ b/core/src/main/scala/sjsonnew/CalendarFormats.scala
@@ -17,28 +17,13 @@
 package sjsonnew
 
 import java.util.{Date, TimeZone, Calendar}
-import java.text.SimpleDateFormat
+import javax.xml.bind.DatatypeConverter
 
 trait CalendarFormats {
   self: IsoFormats =>
 
-  private val dateFormatTemplate = {
-    val format =
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") //use ISO_8601 format
-    format.setLenient(false)
-    format.setTimeZone(TimeZone.getTimeZone("UTC"))
-    format
-  }
-  private def clonedDateFormat =
-    dateFormatTemplate.clone.asInstanceOf[SimpleDateFormat]
   implicit val calendarStringIso = {
-    IsoString.iso[Calendar]( (c: Calendar) => {
-        clonedDateFormat.format(c.getTime)
-      },
-      (s: String) => {
-        val c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-        c.setTime(clonedDateFormat.parse(s))
-        c
-      })
+    IsoString.iso[Calendar]( (c: Calendar) => DatatypeConverter.printDateTime(c),
+      (s: String) => DatatypeConverter.parseDateTime(s))
   }
 }

--- a/support/spray/src/test/scala/sjsonnew/support/spray/CalendarFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/CalendarFormatsSpec.scala
@@ -23,14 +23,27 @@ import java.util.{ Calendar, TimeZone }
 
 class CalendarFormatsSpec extends Specification with BasicJsonProtocol {
   "The dateStringIso" should {
-    val c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-    c.clear
-    c.set(1999, 1, 1, 0, 0, 0)
+    val seconds = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    seconds.clear
+    seconds.set(1999, 1, 1, 0, 0, 0)
+    val milliseconds = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    milliseconds.clear
+    milliseconds.set(1999, 1, 1, 0, 0, 0)
+    milliseconds.set(Calendar.MILLISECOND, 1)
     "convert a Date to JsString" in {
-      Converter.toJsonUnsafe(c) mustEqual JsString("1999-02-01T00:00:00.000Z")
+      Converter.toJsonUnsafe(seconds) mustEqual JsString("1999-02-01T00:00:00Z")
+    }
+    "convert a Date with milliseconds to JsString" in {
+      Converter.toJsonUnsafe(milliseconds) mustEqual JsString("1999-02-01T00:00:00.001Z")
     }
     "convert the JsString back to the Date" in {
-      Converter.fromJsonUnsafe[Calendar](JsString("1999-02-01T00:00:00.000Z")).getTimeInMillis mustEqual c.getTimeInMillis
+      Converter.fromJsonUnsafe[Calendar](JsString("1999-02-01T00:00:00Z")).getTimeInMillis mustEqual seconds.getTimeInMillis
+    }
+    "convert the JsString with milliseconds back to the Date" in {
+      Converter.fromJsonUnsafe[Calendar](JsString("1999-02-01T00:00:00.001Z")).getTimeInMillis mustEqual milliseconds.getTimeInMillis
+    }
+    "convert the JsString with no time back to the Date" in {
+      Converter.fromJsonUnsafe[Calendar](JsString("1999-02-01Z")).getTimeInMillis mustEqual seconds.getTimeInMillis
     }
   }
 }


### PR DESCRIPTION
This uses JAXB's [DatatypeConverter](https://docs.oracle.com/javase/7/docs/api/javax/xml/bind/DatatypeConverter.html).

XML Schema Part 2 has a robust handling of date time based on ISO 8601
with or without the time component, and with or without the millisecond
component.