### PR TITLE
Build configuration for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val root = (project in file(".")).
         Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("https://github.com/eed3si9n"))
       ),
       version := "0.4.3-SNAPSHOT",
-      crossScalaVersions := Seq("2.10.6", "2.11.8"),
+      crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
       scalaVersion := "2.11.8",
       description := "A Scala library for JSON (de)serialization",
       licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,15 +3,15 @@ import Keys._
 
 object Dependencies {
   lazy val testDependencies = Seq(
-    "org.specs2" %% "specs2-core" % "3.7.1" % "test",
-    "org.specs2" %% "specs2-scalacheck" % "3.7.1" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+    "org.specs2" %% "specs2-core" % "3.8.6" % "test",
+    "org.specs2" %% "specs2-scalacheck" % "3.8.6" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   )
-  lazy val sprayJson = "io.spray" %% "spray-json" % "1.3.1"
-  lazy val scalaJson = "org.mdedetrich" %% "scala-json-ast" % "1.0.0-M1"
+  lazy val sprayJson = "io.spray" %% "spray-json" % "1.3.2"
+  lazy val scalaJson = "org.mdedetrich" %% "scala-json-ast" % "1.0.0-M4"
   lazy val msgpackCore = "org.msgpack" % "msgpack-core" % "0.8.7"
-  lazy val jawnVersion = "0.8.4"
+  lazy val jawnVersion = "0.10.4"
   lazy val jawnParser = "org.spire-math" %% "jawn-parser" % jawnVersion
   lazy val jawnSpray = "org.spire-math" %% "jawn-spray" % jawnVersion
   lazy val lm = "org.scala-sbt" %% "librarymanagement" % "0.1.0-M11"


### PR DESCRIPTION
including version update of jawn: 0.8.4 -> 0.10.4
and test dependency updates
specs2: 3.7.1 -> 3.8.6
scalacheck: 1.12.5 -> 1.13.4
scalacheck: 2.2.6 -> 3.0.1

all dependencies are available and test pass for scala 2.10, 2.11 and 2.12

A new release would be appreciated! 