### PR TITLE
Write out field names for LList as $fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val root = (project in file(".")).
       developers := List(
         Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("https://github.com/eed3si9n"))
       ),
-      version := "0.6.0",
+      version := "0.6.1-SNAPSHOT",
       isSnapshot := (isSnapshot or version(_ endsWith "-SNAPSHOT")).value,
       crossScalaVersions := Seq("2.10.6", "2.11.8", scala212),
       scalaVersion := "2.11.8",

--- a/core/src/main/scala/sjsonnew/Builder.scala
+++ b/core/src/main/scala/sjsonnew/Builder.scala
@@ -140,8 +140,11 @@ class Builder[J](facade: BuilderFacade[J]) {
   def beginPreObject(): Unit =
     state match {
       case Begin | InArray | InField =>
-        val context = facade.objectContext()
-        contexts ::= context
+        val p = precontext match {
+          case Some(x) => x
+          case None    => facade.objectContext()
+        }
+        contexts ::= p
         state = InObject
       case InObject => stateError(InObject) // expecting field name
       case End => stateError(End)

--- a/core/src/main/scala/sjsonnew/package.scala
+++ b/core/src/main/scala/sjsonnew/package.scala
@@ -20,6 +20,9 @@ package object sjsonnew {
 
   def jsonReader[A](implicit reader: JsonReader[A]): JsonReader[A] = reader
   def jsonWriter[A](implicit writer: JsonWriter[A]): JsonWriter[A] = writer
+
+  type LNil = LList.LNil0
+  val LNil = LList.LNil0
 }
 
 package sjsonnew {

--- a/support/msgpack/src/test/scala/sjonnew/support/msgpack/MsgpackSpec.scala
+++ b/support/msgpack/src/test/scala/sjonnew/support/msgpack/MsgpackSpec.scala
@@ -174,14 +174,23 @@ class MsgpackSpec extends FlatSpec with BasicJsonProtocol {
   lazy val a1 = ("a", 1) :*: LNil
   lazy val ba1 = ("b", a1) :*: LNil
   lazy val a1Message = fromHex(
-    "81 " +    // Fix map for 1 entry
+    "82 " +    // Fix map for 2 entry
+    "A7 24 66 69 65 6C 64 73 " + // string of length 7, "$fields"
+    "91 " + // array with single item
+    "A1 61 " + // string of length 1, "a" (0x61)
     "A1 61 " + // string of length 1, "a" (0x61)
     "01"       // 1
     )
   lazy val ba1Message = fromHex(
-    "81 " +    // Fix map for 1 entry
+    "82 " +    // Fix map for 1 entry
+    "A7 24 66 69 65 6C 64 73 " + // string of length 7, "$fields"
+    "91 " + // array with single item
     "A1 62 " + // string of length 1, "b" (0x62)
-    "81 " +    // Fix map for 1 entry
+    "A1 62 " + // string of length 1, "b" (0x62)
+    "82 " +    // Fix map for 1 entry
+    "A7 24 66 69 65 6C 64 73 " + // string of length 7, "$fields"
+    "91 " + // array with single item
+    "A1 61" +  // string of length 1, "a" (0x61)
     "A1 61" +  // string of length 1, "a" (0x61)
     "01"       // 1
     )

--- a/support/murmurhash/src/test/scala/sjsonnew/support/murmurhash/MurmurhashSpec.scala
+++ b/support/murmurhash/src/test/scala/sjsonnew/support/murmurhash/MurmurhashSpec.scala
@@ -101,5 +101,5 @@ class MurmurhashSpec extends FlatSpec with BasicJsonProtocol {
   lazy val emptyHash = -1609326920
   lazy val a1 = ("a", 1) :*: LNil
   lazy val ba1 = ("b", a1) :*: LNil
-  lazy val a1Hash = -521317128
+  lazy val a1Hash = 1371594665
 }

--- a/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/ScalaJsonSpec.scala
+++ b/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/ScalaJsonSpec.scala
@@ -35,8 +35,9 @@ class ScalaJsonSpec extends FlatSpec {
   )
 
   val bob = Peep("Bob", 23)
-  val bobJson = JObject(JField("name", JString("Bob")), JField("age", JNumber(23)))
-  val bobJsonStr = """{"name":"Bob","age":23}"""
+  val bobJson = JObject(JField("$fields", JArray(JString("name"), JString("age"))),
+    JField("name", JString("Bob")), JField("age", JNumber(23)))
+  val bobJsonStr = """{"$fields":["name","age"],"name":"Bob","age":23}"""
 
   it should "Peep.toJson correctly"              in assert(bob.toJson === bobJson)
   it should "Peep.toJsonStr correctly"           in assert(bob.toJsonStr === bobJsonStr)

--- a/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
@@ -36,13 +36,17 @@ class IsoLListFormatSpec extends Specification with BasicJsonProtocol {
     { in: String :*: Option[Int] :*: LNil => Organization(
       in.find[String]("name").get,
       in.find[Option[Int]]("value").flatten) })
-  implicit val ContactFormat: JsonFormat[Contact] = unionFormat2[Contact, Person, Organization]
+  implicit val ContactFormat: JsonFormat[Contact] = flatUnionFormat2[Contact, Person, Organization]("$type")
   val p1 = Person("Alice", Some(1))
-  val personJs = JsObject("name" -> JsString("Alice"), "value" -> JsNumber(1))
+  val personJs = JsObject("$fields" -> JsArray(JsString("name"), JsString("value")),
+    "name" -> JsString("Alice"), "value" -> JsNumber(1))
   val c1: Contact = Organization("Company", None)
   val contactJs =
-    JsObject("value" -> JsObject("name" -> JsString("Company")),
-      "type" -> JsString("Organization"))
+    JsObject(
+      "$type" -> JsString("Organization"),
+      "$fields" -> JsArray(JsString("name"), JsString("value")),
+      "name" -> JsString("Company")
+    )
   "The isomorphism from a custom type to LList" should {
     "convert from value to JObject" in {
       Converter.toJsonUnsafe(p1) mustEqual personJs

--- a/support/spray/src/test/scala/sjsonnew/support/spray/LListFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/LListFormatSpec.scala
@@ -27,10 +27,10 @@ class LListFormatsSpec extends Specification with BasicJsonProtocol {
   "The llistFormat" should {
     val empty = LNil
     val emptyObject = JsObject()
-    val list = ("a", 1) :*: LNil
-    val obj = JsObject("a" -> JsNumber(1))
+    val list = ("Z", 2) :*: ("a", 1) :*: LNil
+    val obj = JsObject("$fields" -> JsArray(JsString("Z"), JsString("a")), "Z" -> JsNumber(2), "a" -> JsNumber(1))
     val nested = ("b", list) :*: LNil
-    val nestedObj = JsObject("b" -> obj)
+    val nestedObj = JsObject("$fields" -> JsArray(JsString("b")), "b" -> obj)
     "convert an empty list to JObject" in {
       Converter.toJsonUnsafe(empty) mustEqual emptyObject
     }
@@ -41,10 +41,10 @@ class LListFormatsSpec extends Specification with BasicJsonProtocol {
       Converter.toJsonUnsafe(nested) mustEqual nestedObj
     }
     "convert a JObject to list" in {
-      Converter.fromJsonUnsafe[Int :*: LNil](obj) mustEqual list
+      Converter.fromJsonUnsafe[Int :*: Int :*: LNil](obj) mustEqual list
     }
     "convert a nested JObject to list" in {
-      Converter.fromJsonUnsafe[(Int :*: LNil) :*: LNil](nestedObj) mustEqual nested
+      Converter.fromJsonUnsafe[(Int :*: Int :*: LNil) :*: LNil](nestedObj) mustEqual nested
     }
 
     val obj2 = JsObject("f" -> JsString("foo"))

--- a/support/spray/src/test/scala/sjsonnew/support/spray/LListFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/LListFormatSpec.scala
@@ -47,14 +47,14 @@ class LListFormatsSpec extends Specification with BasicJsonProtocol {
       Converter.fromJsonUnsafe[(Int :*: Int :*: LNil) :*: LNil](nestedObj) mustEqual nested
     }
 
-    val obj2 = JsObject("f" -> JsString("foo"))
-    val nested2Obj = JsObject("b" -> obj, "c" -> obj2)
+    val obj2 = JsObject("$fields" -> JsArray(JsString("f")), "f" -> JsString("foo"))
+    val nested2Obj = JsObject("$fields" -> JsArray(JsString("b"), JsString("c")), "b" -> obj, "c" -> obj2)
 
     val list2 = ("f", "foo") :*: LNil
     val nested2 = ("b", list) :*: ("c", list2) :*: LNil
 
     "convert a 2 nested JObjects to list" in {
-      Converter.fromJsonUnsafe[(Int :*: LNil) :*: (String :*: LNil) :*: LNil](nested2Obj) mustEqual nested2
+      Converter.fromJsonUnsafe[(Int :*: Int :*: LNil) :*: (String :*: LNil) :*: LNil](nested2Obj) mustEqual nested2
     }
   }
 }


### PR DESCRIPTION
Fixes #36

To deserialize an LList, the AST must preserve the insertion order, which is not guaranteed according to the JSON spec.
This works around the issue by persisting the field names.
