### PR TITLE
Fix benchmarks for msgpack

### DIFF
--- a/support/spray/src/main/scala/sjsonnew/support/spray/Converter.scala
+++ b/support/spray/src/main/scala/sjsonnew/support/spray/Converter.scala
@@ -76,8 +76,11 @@ object Converter extends SupportConverter[JsValue] {
       value match {
         case x: JsObject =>
           val fields = x.fields
-          val names = (x.fields map { case (k, v) => k }).toVector
-          (fields, names)
+          val vectorBuilder = Vector.newBuilder[String]
+          for (field <- fields) {
+            vectorBuilder += field._1
+          }
+          (fields, vectorBuilder.result())
         case x => deserializationError("Expected Map as JsObject, but got " + x)
       }
   }


### PR DESCRIPTION
Msgpack is in clear disadvantage since it has to translate from the Java API to
the Scala API (collections).

This PR fixes:

* JMH issue -- suite was benchmarking data generation.
* Msgpack performance issue for objects and arrays. We were using *JavaConversions* which is highly inefficient for lots of data.
* Up the level of the generated file to stress more serialization/deserialization.

Two notes:
* The benchmarks are still unrealistic -- the generated data has to be highly
  nested and structure, and not flat (as it is right now). It's not
  representative of a real-world scenario.
* If it were not by the collections conversions, msgpack could be more
  efficient than Spray JSON. However, for the moment, gzipped spray json is the
  winner.

These benchmarks should be merged with the ones done by @dkomanov: https://medium.com/@dkomanov/scala-serialization-419d175c888a.

The highly regarded serialization benchmark suite in the JVM is http://eishay.github.io/jvm-serializers/prototype-results-page/#.

We have to be doing something wrong, since that above benchmark and Uber's benchmark
decides that the best solution for fast serialization and small file size is Zlib Messagepack.

http://highscalability.com/blog/2016/3/21/to-compress-or-not-to-compress-that-was-ubers-question.html

Note: sjson-new creates too much abstraction and it's not as efficient as it could be.
Pluggable backends have this deficiency.