### PR TITLE
remove context bounds and lazy vals. use implicit parameters directly

### DIFF
--- a/core/src/main/boilerplate/sjsonnew/TupleFormats.scala.template
+++ b/core/src/main/boilerplate/sjsonnew/TupleFormats.scala.template
@@ -21,13 +21,11 @@ package sjsonnew
 trait TupleFormats {
   private[this] type JF[A] = JsonFormat[A] // simple alias for reduced verbosity
 
-  [#implicit def tuple1Format[[#A1 :JF#]]: JF[Tuple1[[#A1#]]] = new RootJsonFormat[Tuple1[[#A1#]]] {
-    [#lazy val a1Format = implicitly[JF[A1]]#
-    ]
+  [#implicit def tuple1Format[[#A1#]](implicit [#A1: JF[A1]#]): JF[Tuple1[[#A1#]]] = new RootJsonFormat[Tuple1[[#A1#]]] {
 
     def write[J](t: Tuple1[[#A1#]], builder: Builder[J]): Unit = {
       builder.beginArray()
-      [#a1Format.write(t._1, builder)#
+      [#A1.write(t._1, builder)#
       ]
       builder.endArray()
     }
@@ -37,11 +35,11 @@ trait TupleFormats {
           unbuilder.beginArray(js)
           [#val a1 = unbuilder.nextElement#
           ]
-          val xs = Tuple1([#a1Format.read(Some(a1), unbuilder)#])
+          val xs = Tuple1([#A1.read(Some(a1), unbuilder)#])
           unbuilder.endArray()
           xs
         case None =>
-          val xs = Tuple1([#a1Format.read(None, unbuilder)#])
+          val xs = Tuple1([#A1.read(None, unbuilder)#])
           xs
       }
   }#


### PR DESCRIPTION
```diff
<   implicit def tuple2Format[A1 :JF, A2 :JF]: JF[Tuple2[A1, A2]] = new RootJsonFormat[Tuple2[A1, A2]] {
<     lazy val a1Format = implicitly[JF[A1]]
<     lazy val a2Format = implicitly[JF[A2]]
---
>   implicit def tuple2Format[A1, A2](implicit A1: JF[A1], A2: JF[A2]): JF[Tuple2[A1, A2]] = new RootJsonFormat[Tuple2[A1, A2]] {
52,53c49,50
<       a1Format.write(t._1, builder)
<       a2Format.write(t._2, builder)
---
>       A1.write(t._1, builder)
>       A2.write(t._2, builder)
62c59
<           val xs = Tuple2(a1Format.read(Some(a1), unbuilder), a2Format.read(Some(a2), unbuilder))
---
>           val xs = Tuple2(A1.read(Some(a1), unbuilder), A2.read(Some(a2), unbuilder))
66c63
<           val xs = Tuple2(a1Format.read(None, unbuilder), a2Format.read(None, unbuilder))
---
>           val xs = Tuple2(A1.read(None, unbuilder), A2.read(None, unbuilder))
```