### PR TITLE
Declare LList.iso2 with 2 param groups

### DIFF
--- a/core/src/main/scala/sjsonnew/LList.scala
+++ b/core/src/main/scala/sjsonnew/LList.scala
@@ -27,8 +27,13 @@ sealed trait LList {
 object LList extends LListFormats {
   type :*:[A1, A2 <: LList] = LCons[A1, A2]
   val :*: = LCons
+
   def iso[A, R0 <: LList: JsonFormat](to0: A => R0, from0: R0 => A): IsoLList.Aux[A, R0] =
     IsoLList.iso[A, R0](to0, from0)
+
+  def iso2[A, R0 <: LList: JsonFormat](to0: A => R0)(from0: R0 => A): IsoLList.Aux[A, R0] =
+    IsoLList.iso[A, R0](to0, from0)
+
   // This is so the return type of LNil becomes LNil, instead of LNil.type.
   val LNil0: LNil0 = new LNil0 {}
   sealed trait LNil0 extends LList {

--- a/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/ScalaJsonSpec.scala
+++ b/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/ScalaJsonSpec.scala
@@ -29,10 +29,9 @@ class ScalaJsonSpec extends FlatSpec {
   import LList.:*:
   type PeepRepr = String :*: Int :*: LNil
 
-  implicit val PeepIso: IsoLList.Aux[Peep, PeepRepr] = LList.iso(
-    { p: Peep => ("name", p.name) :*: ("age", p.age) :*: LNil },
-    { in: PeepRepr => Peep(in.head, in.tail.head) }
-  )
+  implicit val PeepIso: IsoLList.Aux[Peep, PeepRepr] = LList.iso2(
+    { p: Peep => ("name", p.name) :*: ("age", p.age) :*: LNil })
+    { in => Peep(in.head, in.tail.head) }
 
   val bob = Peep("Bob", 23)
 

--- a/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
@@ -26,17 +26,20 @@ class IsoLListFormatSpec extends Specification with BasicJsonProtocol {
   case class Person(name: String, value: Option[Int]) extends Contact
   case class Organization(name: String, value: Option[Int]) extends Contact
 
-  implicit val personIso: IsoLList.Aux[Person, String :*: Option[Int] :*: LNil] = LList.iso(
-    { p: Person => ("name", p.name) :*: ("value", p.value) :*: LNil },
-    { in: String :*: Option[Int] :*: LNil => Person(
+  implicit val personIso: IsoLList.Aux[Person, String :*: Option[Int] :*: LNil] = LList.iso2(
+    { p: Person => ("name", p.name) :*: ("value", p.value) :*: LNil })
+    { in => Person(
       in.find[String]("name").get,
-      in.find[Option[Int]]("value").flatten) })
-  implicit val organizationIso: IsoLList.Aux[Organization, String :*: Option[Int] :*: LNil] = LList.iso(
-    { o: Organization => ("name", o.name) :*: ("value", o.value) :*: LNil },
-    { in: String :*: Option[Int] :*: LNil => Organization(
+      in.find[Option[Int]]("value").flatten) }
+
+  implicit val organizationIso: IsoLList.Aux[Organization, String :*: Option[Int] :*: LNil] = LList.iso2(
+    { o: Organization => ("name", o.name) :*: ("value", o.value) :*: LNil })
+    { in => Organization(
       in.find[String]("name").get,
-      in.find[Option[Int]]("value").flatten) })
+      in.find[Option[Int]]("value").flatten) }
+
   implicit val ContactFormat: JsonFormat[Contact] = flatUnionFormat2[Contact, Person, Organization]("$type")
+
   val p1 = Person("Alice", Some(1))
   val personJs = JsObject("$fields" -> JsArray(JsString("name"), JsString("value")),
     "name" -> JsString("Alice"), "value" -> JsNumber(1))


### PR DESCRIPTION
Using multiple param groups guides type inference so you don't have to
fully qualify the LList type parameter.