### PR TITLE
rename LList.iso2 to LList.isoCurried

### DIFF
--- a/core/src/main/scala/sjsonnew/LList.scala
+++ b/core/src/main/scala/sjsonnew/LList.scala
@@ -36,7 +36,8 @@ object LList extends LListFormats {
   def iso[A, R0 <: LList: JsonFormat](to0: A => R0, from0: R0 => A): IsoLList.Aux[A, R0] =
     IsoLList.iso[A, R0](to0, from0)
 
-  def iso2[A, R0 <: LList: JsonFormat](to0: A => R0)(from0: R0 => A): IsoLList.Aux[A, R0] =
+  /** Curried iso for type inference. */
+  def isoCurried[A, R0 <: LList: JsonFormat](to0: A => R0)(from0: R0 => A): IsoLList.Aux[A, R0] =
     IsoLList.iso[A, R0](to0, from0)
 
   // This is so the return type of LNil becomes LNil, instead of LNil.type.

--- a/notes/0.8.0.markdown
+++ b/notes/0.8.0.markdown
@@ -20,7 +20,7 @@ To avoid runtime errors in the future, sjson-new 0.8.0-M3 provides codec support
 - Adds `mapReader`, `contramapWriter`, `mapKeyReader`, and `contramapKeyWriter`. #49, #50, #51, #58
 - Adds support to LList's JsonFormat to read objects with a `$fields` field. #61 by @dwijnand
 - Adds Tuple1 support to the case class support. #62 by @dwijnand
-- Adds `LList.iso2` as an alternative to `LList.iso` that uses multiple parameter groups to drive type inference. #63 by @dwijnand
+- Adds `LList.isoCurried(to0: A => R0)(from0: R0 => A)` as an alternative to `LList.iso(to0: A => R0, from0: R0 => A)` that uses multiple parameter groups to drive type inference. #63 by @dwijnand
 - Redefines `:*:.unapply` so it mirrors the `:*:` operator. #67 by @dwijnand
 
 ### Bug fixes

--- a/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
@@ -26,13 +26,13 @@ class IsoLListFormatSpec extends Specification with BasicJsonProtocol {
   case class Person(name: String, value: Option[Int]) extends Contact
   case class Organization(name: String, value: Option[Int]) extends Contact
 
-  implicit val personIso: IsoLList.Aux[Person, String :*: Option[Int] :*: LNil] = LList.iso2(
+  implicit val personIso: IsoLList.Aux[Person, String :*: Option[Int] :*: LNil] = LList.isoCurried(
     { p: Person => ("name", p.name) :*: ("value", p.value) :*: LNil })
     { in => Person(
       in.find[String]("name").get,
       in.find[Option[Int]]("value").flatten) }
 
-  implicit val organizationIso: IsoLList.Aux[Organization, String :*: Option[Int] :*: LNil] = LList.iso2(
+  implicit val organizationIso: IsoLList.Aux[Organization, String :*: Option[Int] :*: LNil] = LList.isoCurried(
     { o: Organization => ("name", o.name) :*: ("value", o.value) :*: LNil })
     { in => Organization(
       in.find[String]("name").get,


### PR DESCRIPTION
I got confused within only a few days of looking at the PR what `iso2` was, so I am renaming it.
