### PR TITLE
Remove the guard that elides adding empty collection fields

### DIFF
--- a/core/src/main/scala/sjsonnew/CollectionFormats.scala
+++ b/core/src/main/scala/sjsonnew/CollectionFormats.scala
@@ -32,12 +32,6 @@ trait CollectionFormats {
         list foreach { x => elemFormat.write(x, builder) }
         builder.endArray()
       }
-    override def addField[J](name: String, xs: List[A], builder: Builder[J]): Unit =
-      if (xs.isEmpty) ()
-      else {
-        builder.addFieldName(name)
-        write(xs, builder)
-      }
     def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): List[A] =
       jsOpt match {
         case Some(js) =>
@@ -62,12 +56,6 @@ trait CollectionFormats {
         builder.beginArray()
         array foreach { x => elemFormat.write(x, builder) }
         builder.endArray()
-      }
-    override def addField[J](name: String, xs: Array[A], builder: Builder[J]): Unit =
-      if (xs.isEmpty) ()
-      else {
-        builder.addFieldName(name)
-        write(xs, builder)
       }
     def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Array[A] =
       jsOpt match {
@@ -96,12 +84,6 @@ trait CollectionFormats {
             valueFormat.write(v, builder)
         }
         builder.endObject()
-      }
-    override def addField[J](name: String, m: Map[K, V], builder: Builder[J]): Unit =
-      if (m.isEmpty) ()
-      else {
-        builder.addFieldName(name)
-        write(m, builder)
       }
     def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Map[K, V] =
       jsOpt match {
@@ -145,12 +127,6 @@ trait CollectionFormats {
         builder.beginArray()
         iterable foreach { x => elemFormat.write(x, builder) }
         builder.endArray()
-      }
-    override def addField[J](name: String, xs: I, builder: Builder[J]): Unit =
-      if (xs.isEmpty) ()
-      else {
-        builder.addFieldName(name)
-        write(xs, builder)
       }
     def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): I =
       jsOpt match {

--- a/core/src/main/scala/sjsonnew/LList.scala
+++ b/core/src/main/scala/sjsonnew/LList.scala
@@ -60,27 +60,24 @@ trait LListFormats {
   import BasicJsonProtocol._
 
   implicit val lnilFormat: JsonFormat[LNil] = new JsonFormat[LNil] {
-    def write[J](x: LNil, builder: Builder[J]): Unit =
-      {
-        if (!builder.isInObject) {
-          builder.beginObject()
-        }
-        builder.endObject()
-      }
-    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LNil =
-      {
-        if (unbuilder.isInObject) {
-          unbuilder.endObject()
-        }
-        LList.LNil0
-      }
+    def write[J](x: LNil, builder: Builder[J]): Unit = {
+      if (!builder.isInObject) builder.beginObject()
+      builder.endObject()
+    }
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LNil = {
+      if (unbuilder.isInObject) unbuilder.endObject()
+      LNil
+    }
   }
+
   private val fieldNamesField = "$fields"
-  implicit def lconsFormat[A1: JsonFormat: ClassTag, A2 <: LList: JsonFormat]: JsonFormat[LCons[A1, A2]] = new JsonFormat[LCons[A1, A2]] {
-    val a1Format = implicitly[JsonFormat[A1]]
-    val a2Format = implicitly[JsonFormat[A2]]
-    def write[J](x: LCons[A1, A2], builder: Builder[J]): Unit =
-      {
+
+  implicit def lconsFormat[A1: JsonFormat: ClassTag, A2 <: LList: JsonFormat]: JsonFormat[LCons[A1, A2]] =
+    new JsonFormat[LCons[A1, A2]] {
+      val a1Format: JsonFormat[A1] = implicitly
+      val a2Format: JsonFormat[A2] = implicitly
+
+      def write[J](x: LCons[A1, A2], builder: Builder[J]): Unit = {
         if (!builder.isInObject) {
           builder.beginPreObject()
           builder.addField(fieldNamesField, x.fieldNames)
@@ -90,29 +87,30 @@ trait LListFormats {
         builder.addField(x.name, x.head)(a1Format)
         a2Format.write(x.tail, builder)
       }
-    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LCons[A1, A2] =
-      jsOpt match {
-        case Some(js) =>
-          def objectPreamble(x: J) = {
-            unbuilder.beginPreObject(x)
-            val jf = implicitly[JsonFormat[Vector[String]]]
-            val fieldNames = unbuilder.lookupField(fieldNamesField).map(x => jf.read(Some(x), unbuilder))
-            unbuilder.endPreObject()
-            unbuilder.beginObject(x, fieldNames)
-          }
-          if (!unbuilder.isInObject) objectPreamble(js)
-          if (unbuilder.hasNextField) {
-            val (name, x) = unbuilder.nextField
-            if (unbuilder.isObject(x)) objectPreamble(x)
-            val elem = a1Format.read(Some(x), unbuilder)
-            val tail = a2Format.read(Some(js), unbuilder)
-            LCons(name, elem, tail)
-          }
-          else deserializationError(s"Unexpected end of object: $js")
-        case None =>
-          val elem = a1Format.read(None, unbuilder)
-          val tail = a2Format.read(None, unbuilder)
-          LCons("*", elem, tail)
-      }
-  }
+
+      def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LCons[A1, A2] =
+        jsOpt match {
+          case Some(js) =>
+            def objectPreamble(x: J) = {
+              unbuilder.beginPreObject(x)
+              val jf = implicitly[JsonFormat[Vector[String]]]
+              val fieldNames = unbuilder.lookupField(fieldNamesField).map(x => jf.read(Some(x), unbuilder))
+              unbuilder.endPreObject()
+              unbuilder.beginObject(x, fieldNames)
+            }
+            if (!unbuilder.isInObject) objectPreamble(js)
+            if (unbuilder.hasNextField) {
+              val (name, x) = unbuilder.nextField
+              if (unbuilder.isObject(x)) objectPreamble(x)
+              val elem = a1Format.read(Some(x), unbuilder)
+              val tail = a2Format.read(Some(js), unbuilder)
+              LCons(name, elem, tail)
+            }
+            else deserializationError(s"Unexpected end of object: $js")
+          case None =>
+            val elem = a1Format.read(None, unbuilder)
+            val tail = a2Format.read(None, unbuilder)
+            LCons("*", elem, tail)
+        }
+    }
 }

--- a/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/LListFormatSpec.scala
+++ b/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/LListFormatSpec.scala
@@ -1,0 +1,32 @@
+package sjsonnew
+package support.scalajson.unsafe
+
+import shaded.scalajson.ast.unsafe._
+
+import org.scalatest.FlatSpec
+
+import BasicJsonProtocol._
+
+final class LListFormatSpec extends FlatSpec {
+  case class Foo(xs: Seq[String])
+
+  implicit val isoLList: IsoLList[Foo] = LList.isoCurried(
+    (a: Foo) => "xs" -> a.xs :*: LNil
+  ) { case (_, xs) :*: LNil => Foo(xs) }
+
+  val foo        = Foo(Nil)
+  val fooLList   = "xs" -> List.empty[String] :*: LNil
+  val fooJson    = JObject(JField("$fields", JArray(JString("xs"))), JField("xs", JArray()))
+  val fooJsonStr = """{"$fields":["xs"],"xs":[]}"""
+
+  it should "Foo -> LList"        in assert((isoLList to foo) === fooLList)
+  it should "Foo -> JSON"         in assert(foo.toJson === fooJson)
+  it should "Foo -> JSON string"  in assert(foo.toJsonStr === fooJsonStr)
+  it should "JSON string -> JSON" in assert(fooJsonStr.toJson === fooJson)
+  it should "JSON string -> Foo"  in assert(fooJsonStr.fromJsonStr[Foo] === foo)
+  it should "round trip"          in assertRoundTrip(foo)
+  it should "round trip pretty"   in assertPrettyRoundTrip(foo)
+
+  private def assertRoundTrip[A: JsonWriter : JsonReader](x: A) = assert(x === x.jsonRoundTrip)
+  private def assertPrettyRoundTrip[A: JsonWriter : JsonReader](x: A) = assert(x === x.jsonPrettyRoundTrip)
+}

--- a/support/spray/src/test/scala/sjsonnew/support/spray/CollectionFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/CollectionFormatsSpec.scala
@@ -51,7 +51,13 @@ class CollectionFormatsSpec extends Specification with BasicJsonProtocol {
       }
   }
   val person = Person("x", Nil, Array(), Map(), Vector())
-  val personJson = JsObject("name" -> JsString("x"))
+  val personJson = JsObject(
+    "name" -> JsString("x"),
+    "value" -> JsArray(),
+    "ary" -> JsArray(),
+    "m" -> JsObject(),
+    "vs" -> JsArray()
+  )
 
   case class Peep(name: String)
   implicit object PeepFormat extends JsonFormat[Peep] {


### PR DESCRIPTION
See the added LListFormatSpec for a minimised motivation of this.

UnbuilderContext.ObjectContext assumes that every field in $fields is
present in the JSON (by using `fields.apply` in "fields(names(idx))").

This is in alternative to changing _that_ to Map#get and the downstream
type signature changes.