### PR TITLE
Fixes LListFormats

### DIFF
--- a/core/src/main/scala/sjsonnew/CollectionFormats.scala
+++ b/core/src/main/scala/sjsonnew/CollectionFormats.scala
@@ -108,8 +108,8 @@ trait CollectionFormats {
         case Some(js) =>
           val size = unbuilder.beginObject(js)
           val xs = (1 to size).toList map { x =>
-            val (k, v) = unbuilder.nextField
-            keyFormat.read(k) -> valueFormat.read(Option(v), unbuilder)
+            val (k, v) = unbuilder.nextFieldOpt
+            keyFormat.read(k) -> valueFormat.read(v, unbuilder)
           }
           unbuilder.endObject
           Map(xs: _*)

--- a/core/src/main/scala/sjsonnew/CollectionFormats.scala
+++ b/core/src/main/scala/sjsonnew/CollectionFormats.scala
@@ -109,7 +109,7 @@ trait CollectionFormats {
           val size = unbuilder.beginObject(js)
           val xs = (1 to size).toList map { x =>
             val (k, v) = unbuilder.nextField
-            keyFormat.read(k) -> valueFormat.read(Some(v), unbuilder)
+            keyFormat.read(k) -> valueFormat.read(Option(v), unbuilder)
           }
           unbuilder.endObject
           Map(xs: _*)

--- a/core/src/main/scala/sjsonnew/LList.scala
+++ b/core/src/main/scala/sjsonnew/LList.scala
@@ -101,8 +101,8 @@ trait LListFormats {
             if (!unbuilder.isInObject) objectPreamble(js)
             if (unbuilder.hasNextField) {
               val (name, x) = unbuilder.nextField
-              if (unbuilder.isObject(x)) objectPreamble(x)
-              val elem = a1Format.read(Some(x), unbuilder)
+              if (x != null && unbuilder.isObject(x)) objectPreamble(x)
+              val elem = a1Format.read(Option(x), unbuilder)
               val tail = a2Format.read(Some(js), unbuilder)
               LCons(name, elem, tail)
             }

--- a/core/src/main/scala/sjsonnew/LList.scala
+++ b/core/src/main/scala/sjsonnew/LList.scala
@@ -101,9 +101,11 @@ trait LListFormats {
             if (!unbuilder.isInObject) objectPreamble(js)
             if (unbuilder.hasNextField) {
               val (name, x) = unbuilder.nextField
-              if (x != null && unbuilder.isObject(x)) objectPreamble(x)
-              val elem = a1Format.read(Option(x), unbuilder)
-              val tail = a2Format.read(Some(js), unbuilder)
+              if (unbuilder.isObject(x)) objectPreamble(x)
+              // Elided fields are encoded as JNull in Unbuilder.
+              val optX = if (unbuilder.isJnull(x)) None else Option(x)
+              val elem = a1Format.read(optX, unbuilder)
+              val tail = a2Format.read(Option(js), unbuilder)
               LCons(name, elem, tail)
             }
             else deserializationError(s"Unexpected end of object: $js")

--- a/core/src/main/scala/sjsonnew/LList.scala
+++ b/core/src/main/scala/sjsonnew/LList.scala
@@ -60,27 +60,24 @@ trait LListFormats {
   import BasicJsonProtocol._
 
   implicit val lnilFormat: JsonFormat[LNil] = new JsonFormat[LNil] {
-    def write[J](x: LNil, builder: Builder[J]): Unit =
-      {
-        if (!builder.isInObject) {
-          builder.beginObject()
-        }
-        builder.endObject()
-      }
-    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LNil =
-      {
-        if (unbuilder.isInObject) {
-          unbuilder.endObject()
-        }
-        LList.LNil0
-      }
+    def write[J](x: LNil, builder: Builder[J]): Unit = {
+      if (!builder.isInObject) builder.beginObject()
+      builder.endObject()
+    }
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LNil = {
+      if (unbuilder.isInObject) unbuilder.endObject()
+      LNil
+    }
   }
+
   private val fieldNamesField = "$fields"
-  implicit def lconsFormat[A1: JsonFormat: ClassTag, A2 <: LList: JsonFormat]: JsonFormat[LCons[A1, A2]] = new JsonFormat[LCons[A1, A2]] {
-    val a1Format = implicitly[JsonFormat[A1]]
-    val a2Format = implicitly[JsonFormat[A2]]
-    def write[J](x: LCons[A1, A2], builder: Builder[J]): Unit =
-      {
+
+  implicit def lconsFormat[A1: JsonFormat: ClassTag, A2 <: LList: JsonFormat]: JsonFormat[LCons[A1, A2]] =
+    new JsonFormat[LCons[A1, A2]] {
+      val a1Format: JsonFormat[A1] = implicitly
+      val a2Format: JsonFormat[A2] = implicitly
+
+      def write[J](x: LCons[A1, A2], builder: Builder[J]): Unit = {
         if (!builder.isInObject) {
           builder.beginPreObject()
           builder.addField(fieldNamesField, x.fieldNames)
@@ -90,29 +87,30 @@ trait LListFormats {
         builder.addField(x.name, x.head)(a1Format)
         a2Format.write(x.tail, builder)
       }
-    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LCons[A1, A2] =
-      jsOpt match {
-        case Some(js) =>
-          def objectPreamble(x: J) = {
-            unbuilder.beginPreObject(x)
-            val jf = implicitly[JsonFormat[Vector[String]]]
-            val fieldNames = unbuilder.lookupField(fieldNamesField).map(x => jf.read(Some(x), unbuilder))
-            unbuilder.endPreObject()
-            unbuilder.beginObject(x, fieldNames)
-          }
-          if (!unbuilder.isInObject) objectPreamble(js)
-          if (unbuilder.hasNextField) {
-            val (name, x) = unbuilder.nextField
-            if (unbuilder.isObject(x)) objectPreamble(x)
-            val elem = a1Format.read(Some(x), unbuilder)
-            val tail = a2Format.read(Some(js), unbuilder)
-            LCons(name, elem, tail)
-          }
-          else deserializationError(s"Unexpected end of object: $js")
-        case None =>
-          val elem = a1Format.read(None, unbuilder)
-          val tail = a2Format.read(None, unbuilder)
-          LCons("*", elem, tail)
-      }
-  }
+
+      def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): LCons[A1, A2] =
+        jsOpt match {
+          case Some(js) =>
+            def objectPreamble(x: J) = {
+              unbuilder.beginPreObject(x)
+              val jf = implicitly[JsonFormat[Vector[String]]]
+              val fieldNames = unbuilder.lookupField(fieldNamesField).map(x => jf.read(Some(x), unbuilder))
+              unbuilder.endPreObject()
+              unbuilder.beginObject(x, fieldNames)
+            }
+            if (!unbuilder.isInObject) objectPreamble(js)
+            if (unbuilder.hasNextField) {
+              val (name, x) = unbuilder.nextField
+              if (unbuilder.isObject(x)) objectPreamble(x)
+              val elem = a1Format.read(Some(x), unbuilder)
+              val tail = a2Format.read(Some(js), unbuilder)
+              LCons(name, elem, tail)
+            }
+            else deserializationError(s"Unexpected end of object: $js")
+          case None =>
+            val elem = a1Format.read(None, unbuilder)
+            val tail = a2Format.read(None, unbuilder)
+            LCons("*", elem, tail)
+        }
+    }
 }

--- a/core/src/main/scala/sjsonnew/LList.scala
+++ b/core/src/main/scala/sjsonnew/LList.scala
@@ -100,10 +100,10 @@ trait LListFormats {
             }
             if (!unbuilder.isInObject) objectPreamble(js)
             if (unbuilder.hasNextField) {
-              val (name, x) = unbuilder.nextField
-              if (unbuilder.isObject(x)) objectPreamble(x)
-              // Elided fields are encoded as JNull in Unbuilder.
-              val optX = if (unbuilder.isJnull(x)) None else Option(x)
+              val (name, optX) = unbuilder.nextFieldOpt
+              optX foreach { x =>
+                if (unbuilder.isObject(x)) objectPreamble(x)
+              }
               val elem = a1Format.read(optX, unbuilder)
               val tail = a2Format.read(Option(js), unbuilder)
               LCons(name, elem, tail)

--- a/core/src/main/scala/sjsonnew/Unbuilder.scala
+++ b/core/src/main/scala/sjsonnew/Unbuilder.scala
@@ -223,7 +223,7 @@ private[sjsonnew] object UnbuilderContext {
     def hasNext: Boolean = idx < size
     def next: (String, J) = {
       val name = names(idx)
-      val x = fields(names(idx))
+      val x = fields.getOrElse(names(idx), null.asInstanceOf[J])
       idx = idx + 1
       (name, x)
     }

--- a/support/msgpack/src/main/scala/sjonnew/support/msgpack/Converter.scala
+++ b/support/msgpack/src/main/scala/sjonnew/support/msgpack/Converter.scala
@@ -146,6 +146,8 @@ object Converter extends SupportConverter[Value] {
             vectorBuilder += array.next()
           }
           vectorBuilder.result()
+        case ValueType.NIL =>
+          Vector()
         case _ => deserializationError("Expected List as Array, but got " + value)
       }
     def extractObject(value: Value): (Map[String, Value], Vector[String]) =
@@ -162,6 +164,8 @@ object Converter extends SupportConverter[Value] {
             mapBuilder += (keyString -> entry.getValue)
           }
           (mapBuilder.result(), vectorBuilder.result())
+        case ValueType.NIL =>
+          (Map.empty, Vector.empty)
         case _ => deserializationError("Expected Map as MMap, but got " + value)
       }
   }

--- a/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Converter.scala
+++ b/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Converter.scala
@@ -100,6 +100,7 @@ object Converter extends SupportConverter[JValue] {
     def extractArray(value: JValue): Vector[JValue] =
       value match {
         case JArray(elements) => elements.toVector
+        case JNull            => Vector.empty
         case x => deserializationError("Expected List as JArray, but got " + x)
       }
     def extractObject(value: JValue): (Map[String, JValue], Vector[String]) =
@@ -108,6 +109,8 @@ object Converter extends SupportConverter[JValue] {
           val names = (fs map { case JField(k, v) => k }).toVector
           val fields = Map((fs map { case JField(k, v) => (k, v) }): _*)
           (fields, names)
+        case JNull =>
+          (Map.empty, Vector.empty)
         case x => deserializationError("Expected Map as JsObject, but got " + x)
       }
   }

--- a/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/LListFormatSpec.scala
+++ b/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/LListFormatSpec.scala
@@ -1,0 +1,32 @@
+package sjsonnew
+package support.scalajson.unsafe
+
+import shaded.scalajson.ast.unsafe._
+
+import org.scalatest.FlatSpec
+
+import BasicJsonProtocol._
+
+final class LListFormatSpec extends FlatSpec {
+  case class Foo(xs: Seq[String])
+
+  implicit val isoLList: IsoLList[Foo] = LList.isoCurried(
+    (a: Foo) => "xs" -> a.xs :*: LNil
+  ) { case (_, xs) :*: LNil => Foo(xs) }
+
+  val foo        = Foo(Nil)
+  val fooLList   = "xs" -> List.empty[String] :*: LNil
+  val fooJson    = JObject(JField("$fields", JArray(JString("xs"))))
+  val fooJsonStr = """{"$fields":["xs"]}"""
+
+  it should "Foo -> LList"        in assert((isoLList to foo) === fooLList)
+  it should "Foo -> JSON"         in assert(foo.toJson === fooJson)
+  it should "Foo -> JSON string"  in assert(foo.toJsonStr === fooJsonStr)
+  it should "JSON string -> JSON" in assert(fooJsonStr.toJson === fooJson)
+  it should "JSON string -> Foo"  in assert(fooJsonStr.fromJsonStr[Foo] === foo)
+  it should "round trip"          in assertRoundTrip(foo)
+  it should "round trip pretty"   in assertPrettyRoundTrip(foo)
+
+  private def assertRoundTrip[A: JsonWriter : JsonReader](x: A) = assert(x === x.jsonRoundTrip)
+  private def assertPrettyRoundTrip[A: JsonWriter : JsonReader](x: A) = assert(x === x.jsonPrettyRoundTrip)
+}

--- a/support/spray/src/main/scala/sjsonnew/support/spray/Converter.scala
+++ b/support/spray/src/main/scala/sjsonnew/support/spray/Converter.scala
@@ -70,6 +70,7 @@ object Converter extends SupportConverter[JsValue] {
     def extractArray(value: JsValue): Vector[JsValue] =
       value match {
         case JsArray(elements) => elements
+        case JsNull            => Vector.empty
         case x => deserializationError("Expected List as JsArray, but got " + x)
       }
     def extractObject(value: JsValue): (Map[String, JsValue], Vector[String]) =
@@ -81,6 +82,8 @@ object Converter extends SupportConverter[JsValue] {
             vectorBuilder += field._1
           }
           (fields, vectorBuilder.result())
+        case JsNull =>
+          (Map.empty, Vector.empty)
         case x => deserializationError("Expected Map as JsObject, but got " + x)
       }
   }


### PR DESCRIPTION
This is a continuation of https://github.com/eed3si9n/sjson-new/pull/74 by @dwijnand 

When we detect an elided field (a field that's in the "fields" list, but missing from JSON object), the unbuilder will now return `JNull`. This should be fine because we also encode `Option[A]` by not writing out the field when possible, and there's no special meaning attached to JSON `null`.
