### PR TITLE
Encode POSIX file path to URI using u3 (file:///)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies._
+import com.typesafe.tools.mima.core._
 
 val scala210 = "2.10.6"
 val scala211 = "2.11.11"
@@ -63,7 +64,11 @@ lazy val core = project
     name := "sjson new core",
     libraryDependencies ++= testDependencies,
     scalacOptions ++= Seq("-feature", "-language:_", "-unchecked", "-deprecation", "-encoding", "utf8"),
-    mimaSettings
+    mimaSettings,
+    mimaBinaryIssueFilters ++= Seq(
+      // private[this] final val
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("sjsonnew.JavaExtraFormats.sjsonnew$JavaExtraFormats$$fileScheme")
+    )
   )
 
 def support(n: String) =

--- a/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
+++ b/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
@@ -39,8 +39,36 @@ trait JavaExtraFormats {
   implicit val urlStringIso: IsoString[URL] = IsoString.iso[URL](
     _.toURI.toASCIIString, (s: String) => (new URI(s)).toURL)
 
+  private[this] final val fileScheme = "file"
+
   implicit val fileStringIso: IsoString[File] = IsoString.iso[File](
-    _.toPath.toUri.toASCIIString, (s: String) => new File(new URI(s)))
+    (f: File) => {
+      if (f.isAbsolute) {
+        f.toPath.toUri.toASCIIString
+      } else {
+        new URI(fileScheme, normalizeName(f.getPath), null).toASCIIString
+      }
+    },
+    (s: String) => uriToFile(new URI(s)))
+
+  private[this] def normalizeName(name: String) = {
+    val sep = File.separatorChar
+    if (sep == '/') name else name.replace(sep, '/')
+  }
+
+  private[this] def uriToFile(uri: URI): File = {
+    assert(
+      uri.getScheme == fileScheme,
+      "Expected protocol to be '" + fileScheme + "' in URI " + uri
+    )
+    val part = uri.getSchemeSpecificPart
+    Option(uri.getAuthority) match {
+      case None if part startsWith "/" => new File(uri)
+      case _                           =>
+        if (!(part startsWith "/") && (part contains ":")) new File("//" + part)
+        else new File(part)
+    }
+  }
 
   implicit def optionalFormat[A :JF]: JF[Optional[A]] = new OptionalFormat[A]
   final class OptionalFormat[A :JF] extends JF[Optional[A]] {

--- a/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
+++ b/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
@@ -40,7 +40,7 @@ trait JavaExtraFormats {
     _.toURI.toASCIIString, (s: String) => (new URI(s)).toURL)
 
   implicit val fileStringIso: IsoString[File] = IsoString.iso[File](
-    _.toURI.toASCIIString, (s: String) => new File(new URI(s)))
+    _.toPath.toUri.toASCIIString, (s: String) => new File(new URI(s)))
 
   implicit def optionalFormat[A :JF]: JF[Optional[A]] = new OptionalFormat[A]
   final class OptionalFormat[A :JF] extends JF[Optional[A]] {

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
@@ -78,10 +78,10 @@ class JavaExtraFormatsSpec extends Specification with BasicJsonProtocol {
   "The fileStringIso" should {
     val f = new File("/tmp")
     "convert a File to JsString" in {
-      Converter.toJsonUnsafe(f) mustEqual JsString("file:/tmp/")
+      Converter.toJsonUnsafe(f) mustEqual JsString("file:///tmp/")
     }
     "convert the JsString back to the URI" in {
-      Converter.fromJsonUnsafe[File](JsString("file:/tmp/")) mustEqual f
+      Converter.fromJsonUnsafe[File](JsString("file:///tmp/")) mustEqual f
     }
   }
 

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
@@ -77,11 +77,18 @@ class JavaExtraFormatsSpec extends Specification with BasicJsonProtocol {
 
   "The fileStringIso" should {
     val f = new File("/tmp")
+    val f2 = new File("src")
     "convert a File to JsString" in {
       Converter.toJsonUnsafe(f) mustEqual JsString("file:///tmp/")
     }
-    "convert the JsString back to the URI" in {
+    "convert a relative path to JsString" in {
+      Converter.toJsonUnsafe(f2) mustEqual JsString("file:src")
+    }
+    "convert the JsString back to the File" in {
       Converter.fromJsonUnsafe[File](JsString("file:///tmp/")) mustEqual f
+    }
+    "convert the JsString back to the relative path" in {
+      Converter.fromJsonUnsafe[File](JsString("file:src")) mustEqual f2
     }
   }
 


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/3801
Ref https://github.com/sbt/io/pull/96

Under RFC 8089, published in February 2017, an aboslute POSIX file path can be encoded into URI in two different ways.

First is `file:/etc/hosts` with no authority field. Let's call this u1 notation. u1 is the new, minimal representation, and it's what we have been doing (i.e via `f.toURI`) by accident.

Second is `file:///etc/hosts` with an empty authority field. Let's call this u3 notation. u3 is how traditionally file path were supposed to be represented in RFC 3986 (2005) and Kerwin draft (2013). Due to sbt server, we are going to interface non-JVM systems that might not be up to RFC 8089.

For example, Vim's LSP sends URI using u3 `{"textDocument":{"uri":"file:///Users/foo/work/hellotest/Hello.scala"}})`, and more importantly it also *expects* u3 for the compiler error messages to be notified correctly.

https://github.com/sbt/sbt/issues/3702 reported that Atom also expected u3 notation until https://github.com/atom/atom-languageclient/pull/129 fixed it.