### PR TITLE
don't put file: scheme for relative path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val core = project
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
       // private[this] final val
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("sjsonnew.JavaExtraFormats.sjsonnew$JavaExtraFormats$$fileScheme")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("sjsonnew.JavaExtraFormats.sjsonnew$JavaExtraFormats$$FileScheme")
     )
   )
 

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
@@ -77,18 +77,19 @@ class JavaExtraFormatsSpec extends Specification with BasicJsonProtocol {
 
   "The fileStringIso" should {
     val f = new File("/tmp")
-    val f2 = new File("src")
+    val f2 = new File(new File("src"), "main")
     "convert a File to JsString" in {
       Converter.toJsonUnsafe(f) mustEqual JsString("file:///tmp/")
     }
     "convert a relative path to JsString" in {
-      Converter.toJsonUnsafe(f2) mustEqual JsString("file:src")
+      // https://tools.ietf.org/html/rfc3986#section-4.2
+      Converter.toJsonUnsafe(f2) mustEqual JsString("src/main")
     }
     "convert the JsString back to the File" in {
       Converter.fromJsonUnsafe[File](JsString("file:///tmp/")) mustEqual f
     }
     "convert the JsString back to the relative path" in {
-      Converter.fromJsonUnsafe[File](JsString("file:src")) mustEqual f2
+      Converter.fromJsonUnsafe[File](JsString("src/main")) mustEqual f2
     }
   }
 


### PR DESCRIPTION
I messed up in https://github.com/eed3si9n/sjson-new/pull/86/commits/f6471b731498a9c78d2d390eab6f152a40c99315.

Relative path should NOT have file: scheme, according to RFC 3986.