### PR TITLE
Bump jawn to 0.13.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   lazy val sprayJson = "io.spray" %% "spray-json" % "1.3.2"
   lazy val scalaJson = "com.eed3si9n" %% "shaded-scalajson" % "1.0.0-M4"
   lazy val msgpackCore = "org.msgpack" % "msgpack-core" % "0.8.11"
-  lazy val jawnVersion = "0.10.4"
+  lazy val jawnVersion = "0.13.0"
   lazy val jawnParser = "org.spire-math" %% "jawn-parser" % jawnVersion
   lazy val jawnSpray = "org.spire-math" %% "jawn-spray" % jawnVersion
   lazy val lm = "org.scala-sbt" %% "librarymanagement" % "0.1.0-M12"

--- a/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Parser.scala
+++ b/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Parser.scala
@@ -11,19 +11,18 @@ object Parser extends SupportParser[JValue] {
       def jnull() = JNull
       def jfalse() = JFalse
       def jtrue() = JTrue
-      def jnum(s: String) = JNumber(s)
-      def jint(s: String) = JNumber(s)
-      def jstring(s: String) = JString(s)
+      def jnum(s: CharSequence, decIndex: Int, expIndex: Int): JValue = JNumber(s.toString)
+      def jstring(s: CharSequence) = JString(s.toString)
       def singleContext() = new FContext[JValue] {
         var value: JValue = _
-        def add(s: String) = value = jstring(s)
+        def add(s: CharSequence): Unit = jstring(s)
         def add(v: JValue) = value = v
         def finish: JValue = value
         def isObj: Boolean = false
       }
       def arrayContext() = new FContext[JValue] {
         private val vs = ArrayBuffer.empty[JValue]
-        def add(s: String) = vs += jstring(s)
+        def add(s: CharSequence) = vs += jstring(s)
         def add(v: JValue) = vs += v
         def finish: JValue = JArray(vs.toArray)
         def isObj: Boolean = false
@@ -32,7 +31,7 @@ object Parser extends SupportParser[JValue] {
         private var key: String = _
         private var vs = ArrayBuffer.empty[JField]
         private def andNullKey[A](t: => Unit): Unit = { t; key = null }
-        def add(s: String) = if (key == null) key = s else andNullKey(vs += JField(key, jstring(s)))
+        def add(s: CharSequence) = if (key == null) key = s.toString else andNullKey(vs += JField(key, jstring(s)))
         def add(v: JValue) = andNullKey(vs += JField(key, v))
         def finish: JValue = JObject(vs.toArray)
         def isObj: Boolean = true


### PR DESCRIPTION
Simple dependency bump. This release (or actually 0.12.2, but I bumped to the latest version) has a bugfix for nonclosing file.
This bug causes build.json file not being deleted in scripted tests in zinc on windows, which causes tests to fail. There is an easy workaround for that that can be done in zinc directly but I guess we have time and this is more correct method to fix that.