### PR TITLE
Extract classname retrieval while union parsing (performance improvement)

### DIFF
--- a/core/src/main/boilerplate/sjsonnew/FlatUnionFormats.scala.template
+++ b/core/src/main/boilerplate/sjsonnew/FlatUnionFormats.scala.template
@@ -12,6 +12,9 @@ trait FlatUnionFormats {
     [#lazy val a1Format = implicitly[JF[A1]]#
     ]
 
+    [#lazy val a1Name = className(implicitly[Manifest[A1]].runtimeClass)#
+    ]
+
     def write[J](u: U, builder: Builder[J]): Unit = {
       builder.beginPreObject()
       builder.addFieldName(typeFieldName)
@@ -32,7 +35,7 @@ trait FlatUnionFormats {
           }
           unbuilder.endPreObject()
           val value = typeName match {
-          [#  case x if className(implicitly[Manifest[A1]].runtimeClass) == x => a1Format.read(Some(js), unbuilder)#
+          [#  case x if a1Name == x => a1Format.read(Some(js), unbuilder)#
           ]
           }
           value match { case u: U @unchecked => u }


### PR DESCRIPTION
After CPU profiling an `sbt update` run on a our multi-project setup showed the getClassName call in json union parsing to contribute 13% of total CPU time spent. This MR removes that bottleneck (our `sbt update` command went from 40s to 33s)