### PR TITLE
construct URI manually in IsoString[File] to avoid stat call

### DIFF
--- a/benchmark/src/main/scala/sjsonnew/benchmark/FileIsoStringBenchmark.scala
+++ b/benchmark/src/main/scala/sjsonnew/benchmark/FileIsoStringBenchmark.scala
@@ -1,0 +1,17 @@
+package sjsonnew.benchmark
+
+import java.io.File
+
+import org.openjdk.jmh.annotations.Benchmark
+import sjsonnew.IsoString
+
+class FileIsoStringBenchmark {
+
+  @Benchmark
+  def fileB: String = {
+    import sjsonnew.BasicJsonProtocol._
+    val isoFile = implicitly[IsoString[File]]
+    val f = new File("/tmp")
+    isoFile.to(f)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val supportMsgpack = support("msgpack")
 lazy val supportMurmurhash = support("murmurhash")
 
 lazy val shadedJawnParser = (project in file("shaded-jawn-parser"))
-  .enablePlugins(JarjarAbramsPlugin)
+  .enablePlugins(JarjarAbramsPlugin).disablePlugins(MimaPlugin)
   .settings(
     name := "shaded-jawn-parser",
     jarjarLibraryDependency := "org.typelevel" %% "jawn-parser" % "1.0.0",

--- a/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
+++ b/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
@@ -44,7 +44,7 @@ trait JavaExtraFormats {
   implicit val fileStringIso: IsoString[File] = IsoString.iso[File](
     (f: File) => {
       if (f.isAbsolute) {
-        f.toPath.toUri.toASCIIString
+        f.toURI.toASCIIString
       } else {
         new URI(null, normalizeName(f.getPath), null).toASCIIString
       }

--- a/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
+++ b/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
@@ -44,13 +44,18 @@ trait JavaExtraFormats {
   implicit val fileStringIso: IsoString[File] = IsoString.iso[File](
     (f: File) => {
       if (f.isAbsolute) {
-        new URI(FileScheme, normalizeName(f.getAbsolutePath), null).toASCIIString
+        //not using f.toURI to avoid filesystem syscalls
+        new URI(FileScheme, normalizeName(slashify(f.getAbsolutePath)), null).toASCIIString
       } else {
         new URI(null, normalizeName(f.getPath), null).toASCIIString
       }
     },
     (s: String) => uriToFile(new URI(s)))
 
+  private[this] def slashify(name: String) = {
+    if(name.nonEmpty && name.head != File.separatorChar) File.separatorChar + name
+    else name
+  }
   private[this] def normalizeName(name: String) = {
     val sep = File.separatorChar
     if (sep == '/') name else name.replace(sep, '/')

--- a/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
+++ b/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
@@ -44,7 +44,7 @@ trait JavaExtraFormats {
   implicit val fileStringIso: IsoString[File] = IsoString.iso[File](
     (f: File) => {
       if (f.isAbsolute) {
-        f.toURI.toASCIIString
+        new URI(FileScheme, normalizeName(f.getAbsolutePath), null).toASCIIString
       } else {
         new URI(null, normalizeName(f.getPath), null).toASCIIString
       }

--- a/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
+++ b/core/src/main/scala/sjsonnew/JavaExtraFormats.scala
@@ -45,7 +45,8 @@ trait JavaExtraFormats {
     (f: File) => {
       if (f.isAbsolute) {
         //not using f.toURI to avoid filesystem syscalls
-        new URI(FileScheme, normalizeName(slashify(f.getAbsolutePath)), null).toASCIIString
+        //we use empty string as host to force file:// instead of just file:
+        new URI(FileScheme, "", normalizeName(slashify(f.getAbsolutePath)), null).toASCIIString
       } else {
         new URI(null, normalizeName(f.getPath), null).toASCIIString
       }

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
@@ -79,7 +79,7 @@ class JavaExtraFormatsSpec extends Specification with BasicJsonProtocol {
     val f = new File("/tmp")
     val f2 = new File(new File("src"), "main")
     "convert a File to JsString" in {
-      Converter.toJsonUnsafe(f) mustEqual JsString("file:/tmp")
+      Converter.toJsonUnsafe(f) mustEqual JsString("file:///tmp")
     }
     "convert a relative path to JsString" in {
       // https://tools.ietf.org/html/rfc3986#section-4.2

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
@@ -79,7 +79,7 @@ class JavaExtraFormatsSpec extends Specification with BasicJsonProtocol {
     val f = new File("/tmp")
     val f2 = new File(new File("src"), "main")
     "convert a File to JsString" in {
-      Converter.toJsonUnsafe(f) mustEqual JsString("file:///tmp/")
+      Converter.toJsonUnsafe(f) mustEqual JsString("file:/tmp/")
     }
     "convert a relative path to JsString" in {
       // https://tools.ietf.org/html/rfc3986#section-4.2

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
@@ -79,14 +79,14 @@ class JavaExtraFormatsSpec extends Specification with BasicJsonProtocol {
     val f = new File("/tmp")
     val f2 = new File(new File("src"), "main")
     "convert a File to JsString" in {
-      Converter.toJsonUnsafe(f) mustEqual JsString("file:/tmp/")
+      Converter.toJsonUnsafe(f) mustEqual JsString("file:/tmp")
     }
     "convert a relative path to JsString" in {
       // https://tools.ietf.org/html/rfc3986#section-4.2
       Converter.toJsonUnsafe(f2) mustEqual JsString("src/main")
     }
     "convert the JsString back to the File" in {
-      Converter.fromJsonUnsafe[File](JsString("file:///tmp/")) mustEqual f
+      Converter.fromJsonUnsafe[File](JsString("file:///tmp")) mustEqual f
     }
     "convert the JsString back to the relative path" in {
       Converter.fromJsonUnsafe[File](JsString("src/main")) mustEqual f2


### PR DESCRIPTION
Path.toUri does a `stat` to check if it is an directory...

![image](https://user-images.githubusercontent.com/943051/99977615-ca78e200-2d9c-11eb-9e24-23b85d333654.png)

The result is not the same `file:///tmp/` vs `file:/tmp/` but I found this https://stackoverflow.com/questions/46610910/how-to-obtain-correct-uri-of-a-local-file stating that both are valid formats...