### PR TITLE
[0.10.x] Fix Map in LList situation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,34 +11,33 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 8
-            distribution: temurin
+            distribution: zulu
             jobtype: 1
           - os: ubuntu-latest
-            java: 11
+            java: 17
             distribution: temurin
             jobtype: 2
           - os: windows-latest
             java: 11
             distribution: temurin
             jobtype: 1
+          - os: macos-latest
+            java: 8
+            distribution: zulu
+            jobtype: 1
     runs-on: ${{ matrix.os }}
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: "${{ matrix.distribution }}"
         java-version: "${{ matrix.java }}"
-    - name: Coursier cache
-      uses: coursier/cache-action@v6
-    - name: Cache sbt
-      uses: actions/cache@v1
-      with:
-        path: ~/.sbt
-        key: ${{ runner.os }}-sbt-cache-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+        cache: sbt
+    - uses: sbt/setup-sbt@v1
     - name: Build and test (1)
       if: ${{ matrix.jobtype == 1 }}
       shell: bash
@@ -51,11 +50,3 @@ jobs:
         sbt -v --client test
         sbt -v --client mimaReportBinaryIssues
         # sbt -v --client "benchmark2_12/jmh:run -i 10 -wi 3 -f1 -t1"
-    - name: Cleanup
-      shell: bash
-      run: |
-        rm -rf "$HOME/.ivy2/local" || true
-        find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
-        find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
-        find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
-        find $HOME/.sbt                              -name "*.lock"               -delete || true

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val scala212 = "2.12.19"
 val scala213 = "2.13.14"
 val scala3 = "3.3.3"
 
-ThisBuild / version := "0.9.2-SNAPSHOT"
+ThisBuild / version := "0.10.1-SNAPSHOT"
 ThisBuild / scalaVersion := scala212
 lazy val allScalaVersions = Seq(scala212, scala213, scala3)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import Dependencies._
 import com.typesafe.tools.mima.core._
 import sbt.internal.ProjectMatrix
 
-val scala212 = "2.12.15"
-val scala213 = "2.13.8"
-val scala3 = "3.1.0"
+val scala212 = "2.12.19"
+val scala213 = "2.13.14"
+val scala3 = "3.3.3"
 
 ThisBuild / version := "0.9.2-SNAPSHOT"
 ThisBuild / scalaVersion := scala212

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.10.0

--- a/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/LListFormatSpec.scala
+++ b/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/LListFormatSpec.scala
@@ -10,22 +10,30 @@ import BasicJsonProtocol._
 final class LListFormatSpec extends AnyFlatSpec {
   case class Foo(xs: Seq[String])
 
-  implicit val isoLList: IsoLList[Foo] = LList.isoCurried(
+  implicit val fooIso: IsoLList[Foo] = LList.isoCurried(
     (a: Foo) => "xs" -> a.xs :*: LNil
   ) { case (_, xs) :*: LNil => Foo(xs) }
+
+  case class Bar(kv: Map[String, String], x: String)
+
+  implicit val barIso: IsoLList[Bar] = LList.isoCurried(
+    (a: Bar) => "kv" -> a.kv :*: "x" -> a.x :*: LNil
+  ) { case (_, kv) :*: (_, x) :*: LNil => Bar(kv, x) }
 
   val foo        = Foo(Nil)
   val fooLList   = "xs" -> List.empty[String] :*: LNil
   val fooJson    = JObject(JField("$fields", JArray(JString("xs"))), JField("xs", JArray()))
   val fooJsonStr = """{"$fields":["xs"],"xs":[]}"""
+  val bar        = Bar(Map.empty, "bar")
 
-  it should "Foo -> LList"        in assert((isoLList to foo) === fooLList)
+  it should "Foo -> LList"        in assert((fooIso to foo) === fooLList)
   it should "Foo -> JSON"         in assert(foo.toJson === fooJson)
   it should "Foo -> JSON string"  in assert(foo.toJsonStr === fooJsonStr)
   it should "JSON string -> JSON" in assert(fooJsonStr.toJson === fooJson)
   it should "JSON string -> Foo"  in assert(fooJsonStr.fromJsonStr[Foo] === foo)
   it should "round trip"          in assertRoundTrip(foo)
   it should "round trip pretty"   in assertPrettyRoundTrip(foo)
+  it should "round trip map"      in assertRoundTrip(bar)
 
   private def assertRoundTrip[A: JsonWriter : JsonReader](x: A) = assert(x === x.jsonRoundTrip)
   private def assertPrettyRoundTrip[A: JsonWriter : JsonReader](x: A) = assert(x === x.jsonPrettyRoundTrip)


### PR DESCRIPTION
This is a backport of https://github.com/eed3si9n/sjson-new/pull/137

Problem
-------
LList currently calls `unbuilder.beginObject` twice when there's a `Map` as one of the LList elements,
but `beginObject`-`endObject` should be handled via the Map's codec.

Solution
--------
This changes the code to call the second `unbuilder.beginObject` only when we think there's a nested LList.