### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ ThisBuild / developers := List(
   Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("https://github.com/eed3si9n"))
 )
 ThisBuild / description := "A Scala library for JSON (de)serialization"
-ThisBuild / licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / licenses := Seq("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / publishTo := {
   val nexus = "https://oss.sonatype.org/"
   if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaExtraFormatsSpec.scala
@@ -63,7 +63,7 @@ object JavaExtraFormatsSpec extends verify.BasicTestSuite with BasicJsonProtocol
   }
 
   test("The urlStringIso") {
-    val url = new URL("http://localhost")
+    val url = new URI("http://localhost").toURL
     // "convert a URL to JsString" in {
     Predef.assert(Converter.toJsonUnsafe(url) == JsString("http://localhost"))
     // "convert the JsString back to the URI" in {


### PR DESCRIPTION
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String) 
- https://bugs.openjdk.org/browse/JDK-8295949