### PR TITLE
fix warning in Converter.scala

### DIFF
--- a/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Converter.scala
+++ b/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Converter.scala
@@ -39,7 +39,7 @@ object Converter extends SupportConverter[JValue] {
     def objectContext() =
       new FContext[JValue] {
         var key: String = null
-       val vs = mutable.ArrayBuffer.empty[JField]
+        val vs = mutable.ArrayBuffer.empty[JField]
         def addField(s: String): Unit =
           if (key == null) key = s
           else { vs += JField(key, jstring(s)); key = null }


### PR DESCRIPTION
```
[warn] -- Warning: /home/runner/work/sjson-new/sjson-new/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Converter.scala:42:7 
[warn] 42 |       val vs = mutable.ArrayBuffer.empty[JField]
[warn]    |       ^
[warn]    |       Line is indented too far to the left, or a `}` is missing
```