### PR TITLE
Move codecs to the companion objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val scala212 = "2.12.19"
 val scala213 = "2.13.14"
 val scala3 = "3.3.3"
 
-ThisBuild / version := "0.13.0-SNAPSHOT"
+ThisBuild / version := "0.14.0-SNAPSHOT"
 ThisBuild / scalaVersion := scala212
 lazy val allScalaVersions = Seq(scala212, scala213, scala3)
 
@@ -25,7 +25,8 @@ lazy val root = (project in file("."))
 
 val mimaSettings = Def settings (
   mimaPreviousArtifacts := {
-    Set(organization.value %% moduleName.value % "0.14.0-M2")
+    Set.empty
+    // Set(organization.value %% moduleName.value % "0.14.0-M2")
   }
 )
 
@@ -33,7 +34,15 @@ lazy val core = (projectMatrix in file("core"))
   .enablePlugins(BoilerplatePlugin)
   .settings(
     name := "sjson new core",
-    scalacOptions ++= Seq("-Xfuture", "-feature", "-language:_", "-unchecked", "-deprecation", "-encoding", "utf8"),
+    scalacOptions ++= Seq(
+      "-Xsource:3",
+      "-feature",
+      "-language:_",
+      "-unchecked",
+      "-deprecation",
+      "-encoding",
+      "utf8"
+    ),
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
       // private[this] final val
@@ -49,7 +58,14 @@ def support(n: String) =
     .dependsOn(core)
     .settings(
       name := s"sjson-new-$n",
-      scalacOptions ++= Seq("-Xfuture", "-feature", "-language:_", "-unchecked", "-deprecation", "-encoding", "utf8"),
+      scalacOptions ++= Seq(
+        "-Xsource:3",
+        "-feature",
+        "-language:_",
+        "-unchecked",
+        "-deprecation",
+        "-encoding",
+        "utf8"),
       mimaSettings,
     )
 

--- a/core/src/main/scala/sjsonnew/HashWriter.scala
+++ b/core/src/main/scala/sjsonnew/HashWriter.scala
@@ -30,3 +30,5 @@ trait HashWriter[A] {
       write(obj, builder)
     }
 }
+
+object HashWriter extends ImplicitHashWriters

--- a/core/src/main/scala/sjsonnew/IsoStringLong.scala
+++ b/core/src/main/scala/sjsonnew/IsoStringLong.scala
@@ -25,7 +25,7 @@ trait IsoStringLong[A] {
   def from(p: (String, Long)): A
 }
 
-object IsoStringLong {
+object IsoStringLong extends FileIsoStringLongs {
   def iso[A](to0: A => (String, Long), from0: ((String, Long)) => A): IsoStringLong[A] = new IsoStringLong[A] {
     def to(a: A): (String, Long) = to0(a)
     def from(p: (String, Long)): A = from0(p)

--- a/core/src/main/scala/sjsonnew/IsoStringLongFormats.scala
+++ b/core/src/main/scala/sjsonnew/IsoStringLongFormats.scala
@@ -31,6 +31,7 @@ trait IsoStringLongFormats {
     def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A =
       jsOpt match {
         case Some(js) =>
+          import JsonFormat.{ *, given }
           unbuilder.beginObject(js)
           val first = unbuilder.readField[String]("first")
           val second = unbuilder.readField[Long]("second")

--- a/core/src/main/scala/sjsonnew/JsonFormat.scala
+++ b/core/src/main/scala/sjsonnew/JsonFormat.scala
@@ -28,6 +28,8 @@ trait JsonReader[A] {
   def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A
 }
 
+object JsonReader
+
 /**
   * Provides the JSON serialization for type A.
  */
@@ -45,6 +47,19 @@ trait JsonWriter[A] {
   * Provides the JSON deserialization and serialization for type A.
  */
 trait JsonFormat[A] extends JsonReader[A] with JsonWriter[A]
+
+object JsonFormat extends PrimitiveFormats
+  with StandardFormats
+  with TupleFormats
+  with CollectionFormats
+  with AdditionalFormats
+  with UnionFormats
+  with FlatUnionFormats
+  with IsoStringLongFormats
+  with IsoFormats
+  with JavaPrimitiveFormats
+  with ThrowableFormats {
+}
 
 /**
  * A special JsonReader capable of reading a legal JSON root object, i.e. either a JSON array or a JSON object.

--- a/core/src/main/scala/sjsonnew/package.scala
+++ b/core/src/main/scala/sjsonnew/package.scala
@@ -17,20 +17,7 @@
 import scala.reflect.ClassTag
 
 package object sjsonnew
-  extends PrimitiveFormats
-  with StandardFormats
-  with TupleFormats
-  with CollectionFormats
-  with AdditionalFormats
-  with UnionFormats
-  with FlatUnionFormats
-  with IsoStringLongFormats
-  with IsoFormats
-  with JavaPrimitiveFormats
-  with ThrowableFormats
-  with FileIsoStringLongs
-  with ImplicitHashWriters
- {
+  extends AdditionalFormats {
   def deserializationError(msg: String, cause: Throwable = null, fieldNames: List[String] = Nil) = throw new DeserializationException(msg, cause, fieldNames)
   def serializationError(msg: String) = throw new SerializationException(msg)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.2
+sbt.version=1.11.4

--- a/support/msgpack/src/main/scala/sjonnew/support/msgpack/Converter.scala
+++ b/support/msgpack/src/main/scala/sjonnew/support/msgpack/Converter.scala
@@ -58,16 +58,16 @@ object Converter extends SupportConverter[Value] {
 
   implicit val facade: Facade[Value] = FacadeImpl
   private object FacadeImpl extends SimpleFacade[Value] {
-    def jnull()               = ValueFactory.newNil
-    def jfalse()              = ValueFactory.newBoolean(false)
-    def jtrue()               = ValueFactory.newBoolean(true)
-    def jnumstring(s: String) = ValueFactory.newString(s)
-    def jintstring(s: String) = ValueFactory.newInteger(new java.math.BigInteger(s))
-    def jint(i: Int)          = ValueFactory.newInteger(i)
-    def jlong(l: Long)        = ValueFactory.newInteger(l)
-    def jdouble(d: Double)    = ValueFactory.newFloat(d)
-    def jbigdecimal(d: BigDecimal) = ValueFactory.newString(d.toString)
-    def jstring(s: String)    = ValueFactory.newString(s)
+    def jnull(): ImmutableNilValue = ValueFactory.newNil
+    def jfalse(): ImmutableBooleanValue = ValueFactory.newBoolean(false)
+    def jtrue(): ImmutableBooleanValue = ValueFactory.newBoolean(true)
+    def jnumstring(s: String): ImmutableStringValue = ValueFactory.newString(s)
+    def jintstring(s: String): ImmutableIntegerValue = ValueFactory.newInteger(new java.math.BigInteger(s))
+    def jint(i: Int): ImmutableIntegerValue = ValueFactory.newInteger(i)
+    def jlong(l: Long): ImmutableIntegerValue = ValueFactory.newInteger(l)
+    def jdouble(d: Double): ImmutableFloatValue = ValueFactory.newFloat(d)
+    def jbigdecimal(d: BigDecimal): ImmutableStringValue = ValueFactory.newString(d.toString)
+    def jstring(s: String): ImmutableStringValue = ValueFactory.newString(s)
 
     def jarray(vs: List[Value]): Value =
       ValueFactory.newArray(vs.toArray[Value], true)

--- a/support/murmurhash/src/test/scala/sjsonnew/support/murmurhash/MurmurhashSpec.scala
+++ b/support/murmurhash/src/test/scala/sjsonnew/support/murmurhash/MurmurhashSpec.scala
@@ -25,6 +25,7 @@ import LList._
 
 class MurmurhashSpec extends AnyFlatSpec {
   import IsoStringLong.isWindows
+  import sjsonnew.BasicJsonProtocol.{ *, given }
 
   "The IntJsonFormat" should "convert an Int to an int hash" in {
     assert(Hasher.hashUnsafe[Int](1) === 1527037976)

--- a/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Converter.scala
+++ b/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Converter.scala
@@ -7,16 +7,16 @@ import shaded.scalajson.ast.unsafe._
 object Converter extends SupportConverter[JValue] {
   implicit val facade: Facade[JValue] = FacadeImpl
   private object FacadeImpl extends Facade[JValue] {
-    def jnull() = JNull
-    def jfalse() = JFalse
-    def jtrue() = JTrue
-    def jnumstring(s: String) = JNumber(s)
-    def jintstring(s: String) = JNumber(s)
-    def jint(i: Int) = JNumber(i)
-    def jlong(l: Long) = JNumber(l)
-    def jdouble(d: Double) = JNumber(d)
-    def jbigdecimal(d: BigDecimal) = JNumber(d)
-    def jstring(s: String) = JString(s)
+    def jnull(): JNull.type = JNull
+    def jfalse(): JFalse.type = JFalse
+    def jtrue(): JTrue.type = JTrue
+    def jnumstring(s: String): JNumber = JNumber(s)
+    def jintstring(s: String): JNumber = JNumber(s)
+    def jint(i: Int): JNumber = JNumber(i)
+    def jlong(l: Long): JNumber = JNumber(l)
+    def jdouble(d: Double): JNumber = JNumber(d)
+    def jbigdecimal(d: BigDecimal): JNumber = JNumber(d)
+    def jstring(s: String): JString = JString(s)
 
     def singleContext() =
       new FContext[JValue] {

--- a/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Parser.scala
+++ b/support/scalajson/src/main/scala/sjsonnew/support/scalajson/unsafe/Parser.scala
@@ -8,12 +8,13 @@ import shaded.org.typelevel.jawn.{ Facade, FContext, SupportParser }
 object Parser extends SupportParser[JValue] {
   implicit val facade: Facade[JValue] =
     new Facade[JValue] {
-      def jnull(index: Int) = JNull
-      def jfalse(index: Int) = JFalse
-      def jtrue(index: Int) = JTrue
-      def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) = JNumber(s.toString)
-      def jint(s: String) = JNumber(s)
-      def jstring(s: CharSequence, index: Int) = JString(s.toString)
+      def jnull(index: Int): JNull.type = JNull
+      def jfalse(index: Int): JFalse.type = JFalse
+      def jtrue(index: Int): JTrue.type = JTrue
+      def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): JNumber =
+        JNumber(s.toString)
+      def jint(s: String): JNumber = JNumber(s)
+      def jstring(s: CharSequence, index: Int): JString = JString(s.toString)
       def singleContext(index: Int) = new FContext[JValue] {
         var value: JValue = _
         def add(s: CharSequence, index: Int) = value = jstring(s, index)

--- a/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/HList.scala
+++ b/support/scalajson/src/test/scala/sjsonnew/support/scalajson/unsafe/HList.scala
@@ -10,7 +10,30 @@ sealed trait HList {
 }
 
 sealed trait HNil extends HList
-object HNil extends HNil
+object HNil extends HNil {
+  implicit lazy val lnilFormat1: JsonFormat[HNil] = forHNil(HNil)
+  implicit lazy val lnilFormat2: JsonFormat[HNil.type] = forHNil(HNil)
+
+  private def forHNil[A <: HNil](hnil: A): JsonFormat[A] = new JsonFormat[A] {
+    def write[J](x: A, builder: Builder[J]): Unit = {
+      builder.beginArray()
+      builder.endArray()
+    }
+
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A = jsOpt match {
+      case None     => hnil
+      case Some(js) => unbuilder.beginArray(js); unbuilder.endArray(); hnil
+    }
+  }
+
+  implicit lazy val lnilHListJF1: HList.HListJF[HNil]      = hnilHListJF(HNil)
+  implicit lazy val lnilHListJF2: HList.HListJF[HNil.type] = hnilHListJF(HNil)
+
+  implicit def hnilHListJF[A <: HNil](hnil: A): HList.HListJF[A] = new HList.HListJF[A] {
+    def write[J](hcons: A, builder: Builder[J]) = ()
+    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]) = hnil
+  }
+}
 
 final case class HCons[H, T <: HList](head: H, tail: T) extends HList
 
@@ -24,21 +47,6 @@ object HList {
 
   implicit class HConsOps[H, T <: HList](private val _l: HCons[H, T]) extends AnyVal {
     def :+:[G](g: G): G :+: H :+: T = HCons(g, _l)
-  }
-
-  implicit val lnilFormat1: JsonFormat[HNil] = forHNil(HNil)
-  implicit val lnilFormat2: JsonFormat[HNil.type] = forHNil(HNil)
-
-  private def forHNil[A <: HNil](hnil: A): JsonFormat[A] = new JsonFormat[A] {
-    def write[J](x: A, builder: Builder[J]): Unit = {
-      builder.beginArray()
-      builder.endArray()
-    }
-
-    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): A = jsOpt match {
-      case None     => hnil
-      case Some(js) => unbuilder.beginArray(js); unbuilder.endArray(); hnil
-    }
   }
 
   implicit def hconsFormat[H, T <: HList](implicit hf: JsonFormat[H], tf: HListJF[T]): JsonFormat[H :+: T] =
@@ -77,12 +85,4 @@ object HList {
         case Some(js) => HCons(hf.read(Some(unbuilder.nextElement), unbuilder), tf.read(Some(js), unbuilder))
       }
     }
-
-  implicit val lnilHListJF1: HListJF[HNil]      = hnilHListJF(HNil)
-  implicit val lnilHListJF2: HListJF[HNil.type] = hnilHListJF(HNil)
-
-  implicit def hnilHListJF[A <: HNil](hnil: A): HListJF[A] = new HListJF[A] {
-    def write[J](hcons: A, builder: Builder[J]) = ()
-    def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]) = hnil
-  }
 }

--- a/support/spray/src/main/scala/sjsonnew/support/spray/Converter.scala
+++ b/support/spray/src/main/scala/sjsonnew/support/spray/Converter.scala
@@ -6,18 +6,18 @@ import spray.json.{ deserializationError => _, _ }
 object Converter extends SupportConverter[JsValue] {
   val facade: Facade[JsValue] = FacadeImpl
   private object FacadeImpl extends SimpleFacade[JsValue] {
-    def jnull() = JsNull
-    def jfalse() = JsFalse
-    def jtrue() = JsTrue
-    def jdouble(d: Double) = JsNumber(d)
-    def jnumstring(s: String) = JsNumber(s)
-    def jbigdecimal(d: BigDecimal) = JsNumber(d)
-    def jintstring(s: String) = JsNumber(s)
-    def jint(i: Int) = JsNumber(i)
-    def jlong(l: Long) = JsNumber(l)
-    def jstring(s: String) = JsString(s)
-    def jarray(vs: List[JsValue]) = JsArray(vs: _*)
-    def jobject(vs: Map[String, JsValue]) = JsObject(vs)
+    def jnull(): JsNull.type = JsNull
+    def jfalse(): JsFalse.type = JsFalse
+    def jtrue(): JsTrue.type = JsTrue
+    def jdouble(d: Double): JsValue = JsNumber(d)
+    def jnumstring(s: String): JsNumber = JsNumber(s)
+    def jbigdecimal(d: BigDecimal): JsNumber = JsNumber(d)
+    def jintstring(s: String): JsNumber = JsNumber(s)
+    def jint(i: Int): JsNumber = JsNumber(i)
+    def jlong(l: Long): JsNumber = JsNumber(l)
+    def jstring(s: String): JsString = JsString(s)
+    def jarray(vs: List[JsValue]): JsArray = JsArray(vs: _*)
+    def jobject(vs: Map[String, JsValue]): JsObject = JsObject(vs)
     def isJnull(value: JsValue): Boolean =
       value match {
         case JsNull => true

--- a/support/spray/src/test/scala/sjsonnew/support/spray/CollectionFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/CollectionFormatsSpec.scala
@@ -19,9 +19,12 @@ package sjsonnew
 package support.spray
 
 import java.util.Arrays
+import scala.annotation.nowarn
 import spray.json.{ JsArray, JsNumber, JsObject, JsString, JsValue }
 
 object CollectionFormatsSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
+
   case class Person(name: String, value: List[Int], ary: Array[Int],
     m: Map[String, Int], vs: Vector[Int])
   implicit object PersonFormat extends JsonFormat[Person] {
@@ -74,6 +77,7 @@ object CollectionFormatsSpec extends verify.BasicTestSuite {
       case None => deserializationError("Expected JsObject but found None")
     }
   }
+  @nowarn
   implicit val PeepKeyFormat: JsonKeyFormat[Peep] = JsonKeyFormat(_.name, Peep)
   val peep = Peep("x")
 

--- a/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/IsoLListFormatSpec.scala
@@ -20,6 +20,8 @@ package support.spray
 import spray.json.{ JsArray, JsNumber, JsString, JsObject }
 
 object IsoLListFormatSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
+
   sealed trait Contact
   case class Person(name: String, value: Option[Int]) extends Contact
   case class Organization(name: String, value: Option[Int]) extends Contact

--- a/support/spray/src/test/scala/sjsonnew/support/spray/JavaPrimitiveSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/JavaPrimitiveSpec.scala
@@ -23,6 +23,8 @@ import java.lang.{ Integer => JInteger, Long => JLong, Boolean => JBoolean,
   Character => JCharacter }
 
 object JavaPrimitiveFormatsSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
+
   test("The JIntegerJsonFormat") {
     // "convert an JInteger to a JsNumber" in {
     Predef.assert(Converter.toJsonUnsafe[JInteger](42: JInteger) == JsNumber(42))

--- a/support/spray/src/test/scala/sjsonnew/support/spray/PrimitiveFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/PrimitiveFormatsSpec.scala
@@ -21,6 +21,7 @@ package support.spray
 import spray.json.{ JsValue, JsNumber, JsString, JsNull, JsTrue, JsFalse }
 
 object PritimiveFormatsSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
 
   test("The IntJsonFormat") {
     // "convert an Int to a JsNumber"

--- a/support/spray/src/test/scala/sjsonnew/support/spray/StandardFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/StandardFormatsSpec.scala
@@ -22,6 +22,8 @@ import spray.json.{ JsValue, JsNumber, JsString, JsNull, JsTrue, JsFalse, JsObje
 import scala.Right
 
 object StandardFormatsSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
+
   case class Person(name: Option[String], value: Option[Int])
   implicit object PersonFormat extends JsonFormat[Person] {
     def write[J](x: Person, builder: Builder[J]): Unit = {

--- a/support/spray/src/test/scala/sjsonnew/support/spray/ThrowableFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/ThrowableFormatsSpec.scala
@@ -18,6 +18,8 @@ package sjsonnew
 package support.spray
 
 object ThrowableFormatsSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
+
   test("The throwableFormat round trip") {
     val t: Throwable = new Exception("foo", new Exception("bar"))
 

--- a/support/spray/src/test/scala/sjsonnew/support/spray/TupleFormatsSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/TupleFormatsSpec.scala
@@ -22,6 +22,7 @@ import spray.json.{ JsValue, JsNumber, JsString, JsNull, JsTrue, JsFalse, JsArra
 import scala.Right
 
 object TupleFormatsSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
 
   test("The tuple1Format") {
     // "convert (42) to a JsNumber"

--- a/support/spray/src/test/scala/sjsonnew/support/spray/UnionFormatSpec.scala
+++ b/support/spray/src/test/scala/sjsonnew/support/spray/UnionFormatSpec.scala
@@ -22,6 +22,8 @@ import spray.json.{ JsArray, JsNumber, JsString, JsObject }
 import LList._
 
 object UnionFormatsSpec extends verify.BasicTestSuite {
+  import sjsonnew.BasicJsonProtocol.{ *, given }
+
   sealed trait Fruit
   case class Apple() extends Fruit
   sealed trait Citrus extends Fruit


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8207

Scala 3 doesn't use package object as the implicit scope anymore.
