### PR TITLE
Fix build.sbt syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,9 +23,9 @@ lazy val root = (project in file("."))
     mimaPreviousArtifacts := Set.empty,
   )
 
-val mimaSettings = Def settings (
+val mimaSettings = Def.settings(
   mimaPreviousArtifacts := {
-    Set(organization.value %% moduleName.value % "0.14.0"),
+    Set(organization.value %% moduleName.value % "0.14.0")
   }
 )
 


### PR DESCRIPTION
- Avoid infix syntax for sbt 2.x
- Remove unnecessary `,`


```
Welcome to Scala 2.12.21 (OpenJDK 64-Bit Server VM, Java 21.0.11).
Type in expressions for evaluation. Or try :help.

scala> val a = {
     |   Seq(2),
     | }
a: Seq[Int] = List(2)
```

```
Welcome to Scala 3.8.4 (21.0.11, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> val a = {
         Seq(2),
-- Error: ----------------------------------------------------------------------
2 |  Seq(2),
  |        ^
  |        end of statement expected but ',' found
```